### PR TITLE
Add Continuous Integration to the Project using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
       run: docker-compose up
     - uses: actions/upload-artifact@v2
       with:
-        name: ventoy-build
-        path: INSTALL
+        name: ventoy-linux
+        path: INSTALL/ventoy-*linux*
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ventoy-windows
+        path: INSTALL/ventoy-*windows*
 


### PR DESCRIPTION
This is a first pass at automatically building the project on each commit using GitHub Actions.