### PR TITLE
add IMG to no iso tip

### DIFF
--- a/INSTALL/grub/grub.cfg
+++ b/INSTALL/grub/grub.cfg
@@ -1409,11 +1409,11 @@ if [ $ventoy_img_count -gt 0 ]; then
     fi
 else
     if [ -n "$VTOY_NO_ISO_TIP" ]; then
-        NO_ISO_MENU="No ISO files found, $VTOY_NO_ISO_TIP"
+        NO_ISO_MENU="No ISO or supported IMG files found, $VTOY_NO_ISO_TIP"
     elif [ -n "$VTOY_DEFAULT_SEARCH_ROOT" ]; then
-        NO_ISO_MENU="No ISO files found, please check VTOY_DEFAULT_SEARCH_ROOT"
+        NO_ISO_MENU="No ISO or supported IMG files found, please check VTOY_DEFAULT_SEARCH_ROOT"
     else
-        NO_ISO_MENU="No ISO files found"
+        NO_ISO_MENU="No ISO or supported IMG files found"
     fi
     menuentry "$NO_ISO_MENU (Press enter to reboot ...)" {
         echo -e "\n    Rebooting ... "


### PR DESCRIPTION
Currently, if grub can't find any ISOs or supported IMGs it will display an error message.  That error message only mentions that it could not find any ISOs.  This is confusing if there are only unsupported IMG files.   This pull request adds information about IMG files to the error messages.