### PR TITLE
fix Parabola EFI booting

### DIFF
--- a/INSTALL/grub/grub.cfg
+++ b/INSTALL/grub/grub.cfg
@@ -500,10 +500,8 @@ function uefi_linux_menu_func {
                     vt_add_replace_file $vtindex "boot\\initramfs_x86_64.img"
                 fi
             elif [ -d (loop)/parabola ]; then
-                if [ -f (loop)/parabola/boot/x86_64/parabola.img ]; then
-                    vt_add_replace_file $vtindex "EFI\\parabola\\parabola.img"
-                elif [ -f (loop)/boot/initramfs_x86_64.img ]; then
-                    vt_add_replace_file $vtindex "boot\\initramfs_x86_64.img"
+                if [ -f (loop)/parabola/boot/x86_64/parabolaiso.img ]; then
+                    vt_add_replace_file $vtindex "EFI\\parabolaiso\\parabolaiso.img"
                 fi
             elif [ -f (loop)/EFI/BOOT/initrd.gz ]; then
                 vt_add_replace_file $vtindex "EFI\\BOOT\\initrd.gz"


### PR DESCRIPTION
The last PR I made was wrong, and didn't work because I messed up wirth the names (some files/dirs named "parabola" were in fact "parabolaiso")

This one definitively works and allows booting Parabola in EFI mode with systemd-boot.