### PR TITLE
Remove the annoying "unofficial version" nag screen.

### DIFF
--- a/EDK2/edk2_mod/edk2-edk2-stable201911/MdeModulePkg/Application/Ventoy/Ventoy.c
+++ b/EDK2/edk2_mod/edk2-edk2-stable201911/MdeModulePkg/Application/Ventoy/Ventoy.c
@@ -403,17 +403,6 @@ STATIC VOID ventoy_warn_invalid_device(VOID)
     }
 
     flag = TRUE;
-    gST->ConOut->ClearScreen(gST->ConOut);
-    gST->ConOut->OutputString(gST->ConOut, VTOY_WARNING L"\r\n");
-    gST->ConOut->OutputString(gST->ConOut, VTOY_WARNING L"\r\n");
-    gST->ConOut->OutputString(gST->ConOut, VTOY_WARNING L"\r\n\r\n\r\n");
-
-    gST->ConOut->OutputString(gST->ConOut, L"This is NOT a standard Ventoy device and is NOT officially supported.\r\n\r\n");
-    gST->ConOut->OutputString(gST->ConOut, L"You should follow the official instructions in https://www.ventoy.net\r\n");
-    
-    gST->ConOut->OutputString(gST->ConOut, L"\r\n\r\nWill continue to boot after 15 seconds ...... ");
-
-    sleep(15);
 }
 #else
 STATIC VOID ventoy_warn_invalid_device(VOID)


### PR DESCRIPTION
1. If you changed the files, you are already aware that you changed them.
2. Ventoy already shows "unofficial version" in the menu text.
3. The screen forces you to wait for 15 seconds, which is very intrusive.

Note that I am only removing the nag screen; the version check is still there.