### PR TITLE
grub.cfg: add support for new Parabola ISOs

### DIFF
--- a/INSTALL/grub/grub.cfg
+++ b/INSTALL/grub/grub.cfg
@@ -230,6 +230,11 @@ function distro_specify_initrd_file_phase2 {
         if [ -f (loop)/parabola/boot/i686/parabolaiso.img ]; then 
             vt_linux_specify_initrd_file /parabola/boot/i686/parabolaiso.img
         fi
+    elif [ -f (loop)/parabola/boot/x86_64/initramfs-linux-libre.img ]; then
+        vt_linux_specify_initrd_file /parabola/boot/x86_64/initramfs-linux-libre.img
+        if [ -f (loop)/parabola/boot/i686/initramfs-linux-libre.img ]; then
+            vt_linux_specify_initrd_file /parabola/boot/i686/initramfs-linux-libre.img
+        fi
     elif [ -f (loop)/hyperbola/boot/x86_64/hyperiso.img ]; then 
         vt_linux_specify_initrd_file /hyperbola/boot/x86_64/hyperiso.img
         if [ -f (loop)/hyperbola/boot/i686/hyperiso.img ]; then 
@@ -525,6 +530,8 @@ function uefi_linux_menu_func {
             elif [ -d (loop)/parabola ]; then
                 if [ -f (loop)/parabola/boot/x86_64/parabolaiso.img ]; then
                     vt_add_replace_file $vtindex "EFI\\parabolaiso\\parabolaiso.img"
+                elif [ -f (loop)/parabola/boot/x86_64/initramfs-linux-libre.img ]; then
+                    vt_add_replace_file $vtindex "parabola\\boot\\x86_64\\initramfs-linux-libre.img"
                 fi
             elif [ -f (loop)/EFI/BOOT/initrd.gz ]; then
                 vt_add_replace_file $vtindex "EFI\\BOOT\\initrd.gz"
@@ -542,6 +549,8 @@ function uefi_linux_menu_func {
         elif [ -d (loop)/EFI/BOOT/entries ]; then
             if [ -f (loop)/parabola/boot/x86_64/parabolaiso.img ]; then
                 vt_add_replace_file 0 "EFI\\parabolaiso\\parabolaiso.img"
+            elif [ -f (loop)/parabola/boot/x86_64/initramfs-linux-libre.img ]; then
+                vt_add_replace_file $vtindex "parabola\\boot\\x86_64\\initramfs-linux-libre.img"
             fi
         elif [ -e (loop)/syslinux/alt0/full.cz ]; then
             vt_add_replace_file 0 "EFI\\BOOT\\full.cz"            


### PR DESCRIPTION
this PR does the same changes made for Arch, but adapted to Parabola, since Parabola's ISO scripts are based in Arch's