### PR TITLE
Fix for "VentoyWorker.sh: 45: [: /dev/sdX: unexpected operator" and POSIX fixes

### DIFF
--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -3,7 +3,7 @@
 . ./tool/ventoy_lib.sh
 
 print_usage() {
-    
+
     echo 'Usage:  Ventoy2Disk.sh CMD [ OPTION ] /dev/sdX'
     echo '  CMD:'
     echo '   -i  install ventoy to sdX (fail if disk already installed with ventoy)'
@@ -42,7 +42,7 @@ while [ -n "$1" ]; do
         RESERVE_SIZE_MB=$1
     elif [ "$1" = "-V" ] || [ "$1" = "--version" ]; then
         exit 0
-    elif [ "$1" == "-h" ] || [ "$1" = "--help" ]; then
+    elif [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
         print_usage
         exit 0
     else
@@ -53,7 +53,7 @@ while [ -n "$1" ]; do
         fi
         DISK=$1
     fi
-    
+
     shift
 done
 
@@ -67,7 +67,7 @@ if ! [ -b "$DISK" ]; then
     exit 1
 fi
 
-if [ -e /sys/class/block/${DISK#/dev/}/start ]; then
+if [ -e "/sys/class/block/${DISK#/dev/}/start" ]; then
     vterr  "$DISK is a partition, please use the whole disk."
     echo   "For example:"
     vterr  "    sudo sh Ventoy2Disk.sh -i /dev/sdX1 <=== This is wrong"
@@ -77,7 +77,7 @@ if [ -e /sys/class/block/${DISK#/dev/}/start ]; then
 fi
 
 if [ -n "$RESERVE_SPACE" ]; then
-    if echo $RESERVE_SIZE_MB | grep -q '^[0-9][0-9]*$'; then
+    if echo "$RESERVE_SIZE_MB" | grep -q '^[0-9][0-9]*$'; then
         vtdebug "User will reserve $RESERVE_SIZE_MB MB disk space"
     else
         vterr "$RESERVE_SIZE_MB is invalid for reserved space"
@@ -85,7 +85,7 @@ if [ -n "$RESERVE_SPACE" ]; then
     fi
 fi
 
-#check access 
+#check access
 if dd if="$DISK" of=/dev/null bs=1 count=1 >/dev/null 2>&1; then
     vtdebug "root permission check ok ..."
 else
@@ -105,10 +105,10 @@ else
 fi
 
 #check mountpoint
-grep "^$DISK" /proc/mounts | while read mtline; do
-    mtpnt=$(echo $mtline | awk '{print $2}')
+grep "^$DISK" /proc/mounts | while read -r mtline; do
+    mtpnt=$(echo "$mtline" | awk '{print $2}')
     vtdebug "Trying to umount $mtpnt ..."
-    umount $mtpnt >/dev/null 2>&1
+    umount "$mtpnt" >/dev/null 2>&1
 done
 
 if grep "$DISK" /proc/mounts; then
@@ -146,8 +146,8 @@ if [ "$MODE" = "install" ]; then
             exit 1
         fi
     fi
-    
-    version=$(get_disk_ventoy_version $DISK)
+
+    version=$(get_disk_ventoy_version "$DISK")
     if [ $? -eq 0 ]; then
         if [ -z "$FORCE" ]; then
             vtwarn "$DISK already contains a Ventoy with version $version"
@@ -157,20 +157,20 @@ if [ "$MODE" = "install" ]; then
             exit 1
         fi
     fi
-    
-    disk_sector_num=$(cat /sys/block/${DISK#/dev/}/size)
-    disk_size_gb=$(expr $disk_sector_num / 2097152)
 
-    if [ $disk_sector_num -gt 4294967296 ] && [ -z "$VTGPT" ]; then
+    disk_sector_num=$(cat "/sys/block/${DISK#/dev/}/size")
+    disk_size_gb=$(( disk_sector_num / 2097152 ))
+
+    if [ "$disk_sector_num" -gt 4294967296 ] && [ -z "$VTGPT" ]; then
         vterr "$DISK is over 2TB size, MBR will not work on it."
         exit 1
     fi
 
     if [ -n "$RESERVE_SPACE" ]; then
-        sum_size_mb=$(expr $RESERVE_SIZE_MB + $VENTOY_PART_SIZE_MB)
-        reserve_sector_num=$(expr $sum_size_mb \* 2048)
-        
-        if [ $disk_sector_num -le $reserve_sector_num ]; then
+        sum_size_mb=$(( RESERVE_SIZE_MB + VENTOY_PART_SIZE_MB ))
+        reserve_sector_num=$(( sum_size_mb * 2048 ))
+
+        if [ "$disk_sector_num" -le "$reserve_sector_num" ]; then
             vterr "Can't reserve $RESERVE_SIZE_MB MB space from $DISK"
             exit 1
         fi
@@ -178,57 +178,57 @@ if [ "$MODE" = "install" ]; then
 
     #Print disk info
     echo "Disk : $DISK"
-    parted -s $DISK p 2>&1 | grep Model
-    echo "Size : $disk_size_gb GB"    
+    parted -s "$DISK" p 2>&1 | grep Model
+    echo "Size : $disk_size_gb GB"
     if [ -n "$VTGPT" ]; then
         echo "Style: GPT"
     else
         echo "Style: MBR"
-    fi    
-    echo ''
+    fi
+    echo
 
     if [ -n "$RESERVE_SPACE" ]; then
         echo "You will reserve $RESERVE_SIZE_MB MB disk space "
     fi
-    echo ''
+    echo
 
     vtwarn "Attention:"
     vtwarn "You will install Ventoy to $DISK."
     vtwarn "All the data on the disk $DISK will be lost!!!"
-    echo ""
+    echo
 
-    read -p 'Continue? (y/n) '  Answer
+    read -rp 'Continue? (y/n) '  Answer
     if [ "$Answer" != "y" ]; then
         if [ "$Answer" != "Y" ]; then
             exit 0
         fi
     fi
 
-    echo ""
+    echo
     vtwarn "All the data on the disk $DISK will be lost!!!"
-    read -p 'Double-check. Continue? (y/n) '  Answer
+    read -rp 'Double-check. Continue? (y/n) '  Answer
     if [ "$Answer" != "y" ]; then
         if [ "$Answer" != "Y" ]; then
             exit 0
         fi
     fi
 
-    if [ $disk_sector_num -le $VENTOY_SECTOR_NUM ]; then  
+    if [ "$disk_sector_num" -le "$VENTOY_SECTOR_NUM" ]; then
         vterr "No enough space in disk $DISK"
         exit 1
     fi
 
-    if ! dd if=/dev/zero of=$DISK bs=1 count=512 status=none conv=fsync; then
+    if ! dd if=/dev/zero of="$DISK" bs=1 count=512 status=none conv=fsync; then
         vterr "Write data to $DISK failed, please check whether it's in use."
         exit 1
     fi
 
     if [ -n "$VTGPT" ]; then
         vtdebug "format_ventoy_disk_gpt $RESERVE_SIZE_MB $DISK $PARTTOOL ..."
-        format_ventoy_disk_gpt $RESERVE_SIZE_MB $DISK $PARTTOOL
+        format_ventoy_disk_gpt "$RESERVE_SIZE_MB" "$DISK" "$PARTTOOL"
     else
         vtdebug "format_ventoy_disk_mbr $RESERVE_SIZE_MB $DISK $PARTTOOL ..."
-        format_ventoy_disk_mbr $RESERVE_SIZE_MB $DISK $PARTTOOL
+        format_ventoy_disk_mbr "$RESERVE_SIZE_MB" "$DISK" "$PARTTOOL"
     fi
 
     # format part1
@@ -238,7 +238,7 @@ if [ "$MODE" = "install" ]; then
         cmd=./tool/mkexfatfs_32
     fi
 
-    if [ -d ./tool/ ]; then 
+    if [ -d ./tool/ ]; then
         chmod +x -R ./tool/
     fi
 
@@ -250,55 +250,55 @@ if [ "$MODE" = "install" ]; then
         cluster_sectors=64
     fi
 
-    PART1=$(get_disk_part_name $DISK 1)  
-    PART2=$(get_disk_part_name $DISK 2)  
+    PART1=$(get_disk_part_name "$DISK" 1)
+    PART2=$(get_disk_part_name "$DISK" 2)
 
-    $cmd -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
+    $cmd -n "$VTNEW_LABEL" -s "$cluster_sectors" "$PART1"
 
     vtinfo "writing data to disk ..."
-    
-    dd status=none conv=fsync if=./boot/boot.img of=$DISK bs=1 count=446
-    
+
+    dd status=none conv=fsync if=./boot/boot.img of="$DISK" bs=1 count=446
+
     if [ -n "$VTGPT" ]; then
-        echo -en '\x22' | dd status=none of=$DISK conv=fsync bs=1 count=1 seek=92        
-        xzcat ./boot/core.img.xz | dd status=none conv=fsync of=$DISK bs=512 count=2014 seek=34
-        echo -en '\x23' | dd of=$DISK conv=fsync bs=1 count=1 seek=17908 status=none
+        printf '\x22' | dd status=none of="$DISK" conv=fsync bs=1 count=1 seek=92
+        xzcat ./boot/core.img.xz | dd status=none conv=fsync of="$DISK" bs=512 count=2014 seek=34
+        printf '\x23' | dd of="$DISK" conv=fsync bs=1 count=1 seek=17908 status=none
     else
-        xzcat ./boot/core.img.xz | dd status=none conv=fsync of=$DISK bs=512 count=2047 seek=1
+        xzcat ./boot/core.img.xz | dd status=none conv=fsync of="$DISK" bs=512 count=2047 seek=1
     fi
-    
-    xzcat ./ventoy/ventoy.disk.img.xz | dd status=none conv=fsync of=$DISK bs=512 count=$VENTOY_SECTOR_NUM seek=$part2_start_sector
-    
+
+    xzcat ./ventoy/ventoy.disk.img.xz | dd status=none conv=fsync of="$DISK" bs=512 count="$VENTOY_SECTOR_NUM" seek="$part2_start_sector"
+
     #disk uuid
-    ./tool/vtoy_gen_uuid | dd status=none conv=fsync of=${DISK} seek=384 bs=1 count=16
-    
+    ./tool/vtoy_gen_uuid | dd status=none conv=fsync of="$DISK" seek=384 bs=1 count=16
+
     #disk signature
-    ./tool/vtoy_gen_uuid | dd status=none conv=fsync of=${DISK} skip=12 seek=440 bs=1 count=4
+    ./tool/vtoy_gen_uuid | dd status=none conv=fsync of="$DISK" skip=12 seek=440 bs=1 count=4
 
     vtinfo "sync data ..."
     sync
-    
+
     vtinfo "esp partition processing ..."
-    
+
     sleep 1
     mtpnt=$(grep "^${PART2}" /proc/mounts | awk '{print $2}')
     if [ -n "$mtpnt" ]; then
-        umount $mtpnt >/dev/null 2>&1
+        umount "$mtpnt" >/dev/null 2>&1
     fi
-    
+
     if [ "$SECUREBOOT" != "YES" ]; then
         mkdir ./tmp_mnt
-        
+
         vtdebug "mounting part2 ...."
         for tt in 1 2 3; do
-            if mount ${PART2} ./tmp_mnt; then
+            if mount "$PART2" ./tmp_mnt; then
                 vtdebug "mounting part2 success"
                 break
             fi
-            
+
             mtpnt=$(grep "^${PART2}" /proc/mounts | awk '{print $2}')
             if [ -n "$mtpnt" ]; then
-                umount $mtpnt >/dev/null 2>&1
+                umount "$mtpnt" >/dev/null 2>&1
             fi
             sleep 2
         done
@@ -308,95 +308,92 @@ if [ "$MODE" = "install" ]; then
         rm -f ./tmp_mnt/EFI/BOOT/MokManager.efi
         rm -f ./tmp_mnt/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
         mv ./tmp_mnt/EFI/BOOT/grubx64_real.efi  ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
-        
+
         umount ./tmp_mnt
         rm -rf ./tmp_mnt
     fi
 
-    echo ""
+    echo
     vtinfo "Install Ventoy to $DISK successfully finished."
-    echo ""
-    
+    echo
+
 else
     vtdebug "update ventoy ..."
-    
-    oldver=$(get_disk_ventoy_version $DISK)
+
+    oldver=$(get_disk_ventoy_version "$DISK")
     if [ $? -ne 0 ]; then
         vtwarn "$DISK does not contain ventoy or data corupted"
-        echo ""
+        echo
         vtwarn "Please use -i option if you want to install ventoy to $DISK"
-        echo ""
+        echo
         exit 1
     fi
 
     curver=$(cat ./ventoy/version)
 
     vtinfo "Upgrade operation is safe, all the data in the 1st partition (iso files and other) will be unchanged!"
-    echo ""
+    echo
 
-    read -p "Update Ventoy  $oldver ===> $curver   Continue? (y/n)"  Answer
+    read -rp "Update Ventoy  $oldver ===> $curver   Continue? (y/n)"  Answer
     if [ "$Answer" != "y" ]; then
         if [ "$Answer" != "Y" ]; then
             exit 0
         fi
     fi
 
-    PART2=$(get_disk_part_name $DISK 2)
+    PART2=$(get_disk_part_name "$DISK" 2)
     SHORT_PART2=${PART2#/dev/}
-    part2_start=$(cat /sys/class/block/$SHORT_PART2/start)
-    
-    PART1_TYPE=$(dd if=$DISK bs=1 count=1 skip=450 status=none | ./tool/hexdump -n1 -e  '1/1 "%02X"')
-    
+    part2_start=$(cat "/sys/class/block/$SHORT_PART2/start")
+
+    PART1_TYPE=$(dd if="$DISK" bs=1 count=1 skip=450 status=none | ./tool/hexdump -n1 -e  '1/1 "%02X"')
+
     if [ "$PART1_TYPE" = "EE" ]; then
-        vtdebug "This is GPT partition style ..."        
-        xzcat ./boot/core.img.xz | dd status=none conv=fsync of=$DISK bs=512 count=2014 seek=34
-        echo -en '\x23' | dd of=$DISK conv=fsync bs=1 count=1 seek=17908 status=none
+        vtdebug "This is GPT partition style ..."
+        xzcat ./boot/core.img.xz | dd status=none conv=fsync of="$DISK" bs=512 count=2014 seek=34
+        printf '\x23' | dd of="$DISK" conv=fsync bs=1 count=1 seek=17908 status=none
     else
         vtdebug "This is MBR partition style ..."
-        dd status=none conv=fsync if=./boot/boot.img of=$DISK bs=1 count=440
-    
-        PART1_ACTIVE=$(dd if=$DISK bs=1 count=1 skip=446 status=none | ./tool/hexdump -n1 -e  '1/1 "%02X"')
-        PART2_ACTIVE=$(dd if=$DISK bs=1 count=1 skip=462 status=none | ./tool/hexdump -n1 -e  '1/1 "%02X"')
-        
+        dd status=none conv=fsync if=./boot/boot.img of="$DISK" bs=1 count=440
+
+        PART1_ACTIVE=$(dd if="$DISK" bs=1 count=1 skip=446 status=none | ./tool/hexdump -n1 -e  '1/1 "%02X"')
+        PART2_ACTIVE=$(dd if="$DISK" bs=1 count=1 skip=462 status=none | ./tool/hexdump -n1 -e  '1/1 "%02X"')
+
         vtdebug "PART1_ACTIVE=$PART1_ACTIVE  PART2_ACTIVE=$PART2_ACTIVE"
         if [ "$PART1_ACTIVE" = "00" ] && [ "$PART2_ACTIVE" = "80" ]; then
             vtdebug "change 1st partition active, 2nd partition inactive ..."
-            echo -en '\x80' | dd of=$DISK conv=fsync bs=1 count=1 seek=446 status=none
-            echo -en '\x00' | dd of=$DISK conv=fsync bs=1 count=1 seek=462 status=none
+            printf '\x80' | dd of="$DISK" conv=fsync bs=1 count=1 seek=446 status=none
+            printf '\x00' | dd of="$DISK" conv=fsync bs=1 count=1 seek=462 status=none
         fi
-        xzcat ./boot/core.img.xz | dd status=none conv=fsync of=$DISK bs=512 count=2047 seek=1
+        xzcat ./boot/core.img.xz | dd status=none conv=fsync of="$DISK" bs=512 count=2047 seek=1
     fi
 
-    xzcat ./ventoy/ventoy.disk.img.xz | dd status=none conv=fsync of=$DISK bs=512 count=$VENTOY_SECTOR_NUM seek=$part2_start
+    xzcat ./ventoy/ventoy.disk.img.xz | dd status=none conv=fsync of="$DISK" bs=512 count="$VENTOY_SECTOR_NUM" seek="$part2_start"
 
     sync
-    
+
     if [ "$SECUREBOOT" != "YES" ]; then
         mkdir ./tmp_mnt
-        
+
         vtdebug "mounting part2 ...."
         for tt in 1 2 3; do
-            if mount ${PART2} ./tmp_mnt; then
+            if mount "$PART2" ./tmp_mnt; then
                 vtdebug "mounting part2 success"
                 break
             fi
             sleep 2
         done
-              
+
         rm -f ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
         rm -f ./tmp_mnt/EFI/BOOT/grubx64.efi
         rm -f ./tmp_mnt/EFI/BOOT/MokManager.efi
         rm -f ./tmp_mnt/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
         mv ./tmp_mnt/EFI/BOOT/grubx64_real.efi  ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
-        
+
         umount ./tmp_mnt
         rm -rf ./tmp_mnt
     fi
 
-    echo ""
+    echo
     vtinfo "Update Ventoy to $DISK successfully finished."
-    echo ""
-    
+    echo
 fi
-
-


### PR DESCRIPTION
This morning while upgrading my Ventoy disks from 1.0.27 to 1.0.28 I noticed I was getting a script error using any Ventoy function:
`./tool/VentoyWorker.sh: 45: [: /dev/sdc: unexpected operator`

Changing line 45 from:
`elif [ "$1" == "-h" ] || [ "$1" = "--help" ]; then`
to:
`elif [ "$1" = "-h" ] || [ "$1" = "--help" ]; then`
fixes the above mentioned issue. However, there are still a number of remaining issues, some potentially critical.

Using shellcheck v0.7.1 I simply went down the list and addressed the issues one by one focusing on the ones that matter most first:
1. Added quotes where needed when globbing/word-splitting may be undesired (will need review to make sure globbing/word-splitting isn't desired)
2. Replace expr with $((..))
3. Add -r to read
4. echo "" and echo '' are the same as just plain echo (not an issue and I shouldn't have changed them, I just wanted to make you aware)
5. Replace echo with printf when parameters are used (POSIX echo does not support -e or -n and this script and ventory_lib.sh both misbehave when run in a POSIX environment - dash)

Note that there are now quotes in some locations where an IFS character would not be encountered (eg. /dev/sdX). I quoted them because it doesn't hurt to have them when you don't want globbing/word-splitting but it can cause a serious debugging headache without them.

There are still remaining issues that should be fixed IMHO. I did not want to choose how to approach the solution because this is not my project and there are multiple portable solutions for each issue. The main issues remaining are:
1. SC2039: In POSIX sh, read -p is undefined.
2. Line 270: SC2154: part2_start_sector is referenced but not assigned.