### PR TITLE
Fixed mount error when using a qemu nbd device

### DIFF
--- a/IMG/cpio/ventoy/hook/tinycore/ventoy-disk.sh
+++ b/IMG/cpio/ventoy/hook/tinycore/ventoy-disk.sh
@@ -36,7 +36,7 @@ if [ "$vtdiskname" = "unknown" ]; then
     exit 0
 fi
 
-if echo $vtdiskname | egrep -q "nvme.*p[0-9]$|mmc.*p[0-9]$"; then
+if echo $vtdiskname | egrep -q "(nvme|mmc|nbd).*p[0-9]$"; then
     vPart="${vtdiskname}p2"    
 else
     vPart="${vtdiskname}2"

--- a/IMG/cpio/ventoy/hook/ventoy-hook-lib.sh
+++ b/IMG/cpio/ventoy/hook/ventoy-hook-lib.sh
@@ -87,7 +87,7 @@ wait_for_usb_disk_ready() {
 		usb_disk=$(get_ventoy_disk_name)
         vtlog "wait_for_usb_disk_ready $usb_disk ..."
         
-        if echo $usb_disk | $EGREP -q "nvme|mmc"; then
+        if echo $usb_disk | $EGREP -q "nvme|mmc|nbd"; then
             vtpart2=${usb_disk}p2
         else
             vtpart2=${usb_disk}2
@@ -103,7 +103,7 @@ wait_for_usb_disk_ready() {
 }
 
 check_usb_disk_ready() {
-    if echo $1 | $EGREP -q "nvme|mmc"; then
+    if echo $1 | $EGREP -q "nvme|mmc|nbd"; then
         vtpart2=${1}p2
     else
         vtpart2=${1}2
@@ -121,7 +121,7 @@ is_ventoy_disk() {
 }
 
 not_ventoy_disk() {
-    if echo $1 | $EGREP -q "nvme.*p$|mmc.*p$"; then
+    if echo $1 | $EGREP -q "(nvme|mmc|nbd).*p$"; then
         vtDiskName=${1:0:-1}
     else
         vtDiskName=$1
@@ -486,7 +486,7 @@ ventoy_create_persistent_link() {
 }
 
 ventoy_udev_disk_common_hook() {    
-    if echo $1 | $EGREP -q "nvme.*p[0-9]$|mmc.*p[0-9]$"; then
+    if echo $1 | $EGREP -q "(nvme|mmc|nbd).*p[0-9]$"; then
         VTDISK="${1:0:-2}"    
     else
         VTDISK="${1:0:-1}"
@@ -558,7 +558,7 @@ is_inotify_ventoy_part() {
     if echo $1 | $GREP -q "2$"; then
         if ! [ -e /sys/block/$1 ]; then
             if [ -e /sys/class/block/$1 ]; then
-                if echo $1 | $EGREP -q "nvme|mmc"; then
+                if echo $1 | $EGREP -q "nvme|mmc|nbd"; then
                     vtShortName=${1:0:-2}
                 else
                     vtShortName=${1:0:-1}

--- a/INSTALL/tool/ventoy_lib.sh
+++ b/INSTALL/tool/ventoy_lib.sh
@@ -88,7 +88,7 @@ get_disk_part_name() {
         echo ${DISK}p${2}
     elif echo $DISK | grep -q "/dev/nvme[0-9][0-9]*n[0-9]"; then
         echo ${DISK}p${2}
-    elif echo $DISK | grep -q "/dev/mmcblk[0-9]"; then
+    elif echo $DISK | egrep -q "/dev/(mmcblk|nbd)[0-9]"; then
         echo ${DISK}p${2}
     else
         echo ${DISK}${2}

--- a/LiveCD/VTOY/ventoy/ventoy.sh
+++ b/LiveCD/VTOY/ventoy/ventoy.sh
@@ -20,7 +20,7 @@ get_disk_size() {
 enum_disk() {
     id=1
     rm -f /device.list
-    ls /sys/block/ | egrep 'd[a-z]|nvme|mmc' | while read dev; do
+    ls /sys/block/ | egrep 'd[a-z]|nvme|mmc|nbd' | while read dev; do
         if ! [ -b /dev/$dev ]; then
             continue
         fi

--- a/VtoyTool/vtoydm.c
+++ b/VtoyTool/vtoydm.c
@@ -507,7 +507,7 @@ static int vtoydm_print_linear_table(const char *img_map_file, const char *diskn
                (sector_start << 2), disk_sector_num, 
                diskname, (unsigned long long)chunk[i].disk_start_sector);
         #else
-        if (strstr(diskname, "nvme") || strstr(diskname, "mmc"))
+        if (strstr(diskname, "nvme") || strstr(diskname, "mmc")) || strstr(diskname, "nbd"))
         {
             printf("%u %u linear %sp1 %llu\n", 
                (sector_start << 2), disk_sector_num, 


### PR DESCRIPTION
Running ```Ventoy2Disk.sh -i /dev/nbd0``` gives an error.  It tries to mount ```/dev/nbd02``` instead of ```/dev/nbd0p2```.  This fixes it.