### PR TITLE
[URGENT] fix Parabola rEFInd booting

### DIFF
--- a/INSTALL/grub/grub.cfg
+++ b/INSTALL/grub/grub.cfg
@@ -638,6 +638,8 @@ function uefi_linux_menu_func {
                 vt_add_replace_file 0 "EFI\\hyperiso\\hyperiso.img"
             fi
         elif [ -d (loop)/EFI/BOOT/entries ]; then
+            vt_linux_get_main_initrd_index vtindex
+
             if [ -f (loop)/parabola/boot/x86_64/parabolaiso.img ]; then
                 vt_add_replace_file 0 "EFI\\parabolaiso\\parabolaiso.img"
             elif [ -f (loop)/parabola/boot/x86_64/initramfs-linux-libre.img ]; then


### PR DESCRIPTION
newer Parabola rEFInd ISOs need to run vt_linux_get_main_initrd_index to actually work, just like the systemd-boot ISOs

otherwise one will get the typical mounting error of the loop filesystem