### PR TITLE
Let the link to build from source also work on gitee and local copies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Most type of OS supported(Windows/WinPE/Linux/Unix/Vmware/Xen...) <br/>
 See [https://www.ventoy.net/en/doc_start.html](https://www.ventoy.net/en/doc_start.html) for detail
 
 # Compile Instructions
-Please refer to [BuildVentoyFromSource.txt](https://github.com/ventoy/Ventoy/blob/master/DOC/BuildVentoyFromSource.txt)
+Please refer to [BuildVentoyFromSource.txt](DOC/BuildVentoyFromSource.txt)
 
 # Document
 Title | Link


### PR DESCRIPTION
The Link linked to a GitHub page. But markdown also support link in the directory: Now the link works in your local markdown viewer, github and gitee, to their own page instead that all redirect to GitHub