### PR TITLE
Mirror action check owner

### DIFF
--- a/.github/workflows/sync2gitee.yml
+++ b/.github/workflows/sync2gitee.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   run:
     name: Sync-GitHub-to-Gitee
+    if: ${{ github.repository_owner == 'ventoy' }}
     runs-on: ubuntu-latest
     steps:
     - name: Mirror the Github repos to Gitee.


### PR DESCRIPTION
执行同步gitee前检查项目所有者，
避免fork之类情况执行了没意义的失败同步，