### PR TITLE
Support `/dev/disk/by-id/` symlinks in command-line installer

### DIFF
--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -63,7 +63,7 @@ while [ -n "$1" ]; do
         # Resolve symlinks now, will be needed to look up information about the device in
         # the /sys/ filesystem, for example /sys/class/block/${DISK#/dev/}/start
         # The main use case is supporting /dev/disk/by-id/ symlinks instead of raw devices
-        if [ -b "$DISK" ]; then
+        if [ -L "$DISK" ]; then
             DISK=$(readlink -e -n "$DISK")
         fi
     fi

--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -60,6 +60,12 @@ while [ -n "$1" ]; do
             exit 1
         fi
         DISK=$1
+        # Resolve symlinks now, will be needed to look up information about the device in
+        # the /sys/ filesystem, for example /sys/class/block/${DISK#/dev/}/start
+        # The main use case is supporting /dev/disk/by-id/ symlinks instead of raw devices
+        if [ -b "$DISK" ]; then
+            DISK=$(readlink -e -n "$DISK")
+        fi
     fi
     
     shift


### PR DESCRIPTION
Currently the command-line installer fails when giving the target device as a `/dev/disk/by-id` symlink (since it tries to access more information about the device in the `/sys/` filesystem, for example `/sys/class/block/${DISK#/dev/}/start`). Many Linux users (including myself) prefer using these `/dev/disk/by-id` symlinks instead of raw device names (especially for dangerous operations such as formatting a device) since this reduces the probability of accidentally using an incorrect device.

This PR will resolve the symlink in the beginning of `VentoyWorker.sh` (directly when parsing the command-line arguments).