### PR TITLE
Add pointer check on dev->disk->dev

### DIFF
--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/commands/legacycfg.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/commands/legacycfg.c
@@ -373,7 +373,7 @@ grub_cmd_legacy_kernel (struct grub_command *mycmd __attribute__ ((unused)),
 	      grub_errno = GRUB_ERR_NONE;
 	    }
 	  dev = grub_device_open (0);
-	  if (dev && dev->disk
+	  if (dev && dev->disk && dev->disk->dev
 	      && dev->disk->dev->id == GRUB_DISK_DEVICE_BIOSDISK_ID
 	      && dev->disk->id >= 0x80 && dev->disk->id <= 0x90)
 	    {


### PR DESCRIPTION
My team and I were taking a look at the source code and found this line (376) that we think may benefit from including an additional pointer check. Since the same line references dev->disk->dev->id, adding a check on dev->disk->dev may help avoid a potential program crash.