### PR TITLE
Update error message to align with sint16 range

### DIFF
--- a/SQUASHFS/squashfs-tools-4.4/squashfs-tools/sort.c
+++ b/SQUASHFS/squashfs-tools-4.4/squashfs-tools/sort.c
@@ -297,7 +297,7 @@ int read_sort_file(char *filename, int source, char *source_path[])
 		} else if((errno == ERANGE) ||
 				(priority < -32768 || priority > 32767)) {
 			ERROR("Sort file \"%s\", entry \"%s\" has priority "
-				"outside range of -32767:32768.\n", filename,
+				"outside range of -32768:32767.\n", filename,
 				line_buffer);
 			goto failed;
 		}


### PR DESCRIPTION
I think this might be a minor typo-- since the conditional checks for `priority` to be in the signed int16 range, the error message should line up with that expected range of values.