### PR TITLE
Add check on length of name.

### DIFF
--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/commands/search.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/commands/search.c
@@ -66,7 +66,7 @@ iterate_device (const char *name, void *data)
   int found = 0;
 
   /* Skip floppy drives when requested.  */
-  if (ctx->no_floppy &&
+  if (ctx->no_floppy && strlen(name) > 2 && 
       name[0] == 'f' && name[1] == 'd' && name[2] >= '0' && name[2] <= '9')
     return 1;
 


### PR DESCRIPTION
My team and I were looking through the Ventoy source code using our AI-based source code anomaly detection tool, [MP-CodeCheck](https://www.merly.ai), and found this line that we think may benefit from a slight adjustment for the sake of maintainability: a check on the length of the string variable `name` before checking its first three characters.

We believe that this string length check helps as a safeguard against undefined behavior with the string character checking.