### PR TITLE
Add length check on command line input

### DIFF
--- a/BUSYBOX/chmod/vtchmod.c
+++ b/BUSYBOX/chmod/vtchmod.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    if (argv[1][0] == '-' && argv[1][1] == '6')
+    if (strlen(argv[1]) > 1 && argv[1][0] == '-' && argv[1][1] == '6')
     {
         struct utsname buf;
         if (0 == uname(&buf))


### PR DESCRIPTION
My team and I were looking through the Ventoy source code using our AI-based source code anomaly detection tool, [MP-CodeCheck](https://www.merly.ai), and found this line that, while currently functioning correctly, may benefit from a slight adjustment for the sake of maintainability: a check on the length of the input string `argv[1]` before checking its first two characters.

This way, a developer who may modify this line in the future, especially if the program checks for longer string prefixes, will be more likely to be conscious of valid string checking to avoid undefined behavior.