### PR TITLE
fix bugs

### DIFF
--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/commands/search.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/commands/search.c
@@ -68,7 +68,7 @@ iterate_device (const char *name, void *data)
   /* Skip floppy drives when requested.  */
   if (ctx->no_floppy &&
       name[0] == 'f' && name[1] == 'd' && name[2] >= '0' && name[2] <= '9')
-    return 1;
+    return 0;
 
   if (g_no_vtoyefi_part && (grub_strcmp(name, g_vtoyefi_dosname) == 0 || grub_strcmp(name, g_vtoyefi_gptname) == 0)) {
     return 0;

--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/theme_loader.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/theme_loader.c
@@ -456,7 +456,8 @@ read_expression (struct parsebuf *p)
       /* Read as a single word -- for numeric values or words without
          whitespace.  */
       start = p->pos;
-      while (has_more (p) && ! is_whitespace (peek_char (p)))
+      while (has_more (p) && ! is_whitespace (peek_char (p))
+             && peek_char (p) != '}')
         read_char (p);
       end = p->pos;
     }


### PR DESCRIPTION
主题配置中，如果把某个 Widget 的属性全部写在一行里，且最后一个属性的值没有加引号，就会出现比较魔幻的错误。
例如
`+ label {text = "@VTOY_ISO_UEFI_DRV@" color = "red" align = "left"}` 正常
`+ label {text = "@VTOY_ISO_UEFI_DRV@" color = "red" align = left}` 出错：
![深度截图_选择区域_20220406190752](https://user-images.githubusercontent.com/10670106/161968264-cc6fdafb-2113-4c51-bd46-94123688d091.png)

