### PR TITLE
remove '=' from reserved space check (GTK)

### DIFF
--- a/LinuxGUI/Ventoy2Disk/GTK/ventoy_gtk.c
+++ b/LinuxGUI/Ventoy2Disk/GTK/ventoy_gtk.c
@@ -936,7 +936,7 @@ void on_part_cfg_ok(GtkWidget *widget, gpointer data)
 
         for (pos = input; *pos; pos++)
         {
-            if (*pos < '0' || *pos >= '9')
+            if (*pos < '0' || *pos > '9')
             {
                 msgbox(GTK_MESSAGE_ERROR, GTK_BUTTONS_OK, "STR_SPACE_VAL_INVALID");
                 return;


### PR DESCRIPTION
removes the (misplaced) '=' in the check of the configured reserved space in the 'on_part_cfg_ok' function.
This caused #1752