### PR TITLE
Fix typo in GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/success_image_report.yml
+++ b/.github/ISSUE_TEMPLATE/success_image_report.yml
@@ -85,7 +85,7 @@ body:
   - type: input
     id: testenv
     attributes:
-      label: Test envrionment
+      label: Test environment
       description: The manufacturer/model and other details about your computer (or VM).
       placeholder: Lenovo Thinkpad T420 laptop
     validations:


### PR DESCRIPTION
Fixing a small typo in the GitHub Issue Template for **`Success image report`**.