### PR TITLE
Update ko_KR (부트 -> 부팅)

### DIFF
--- a/INSTALL/grub/menu/ko_KR.json
+++ b/INSTALL/grub/menu/ko_KR.json
@@ -1,23 +1,19 @@
 {
     "VTLANG_LANGUAGE_NAME": "Korean (한국어)",
-    
-    "VTLANG_STR_HOTKEY_LIST": "번역: 비너스걸 L:언어  F1:도움말  F2:찾아보기  F3:목록보기  F4:로컬부트  F5:도구  F6:확장메뉴",
-    "VTLANG_STR_HOTKEY_TREE": "번역: 비너스걸 L:언어  F1:도움말  F2:찾아보기  F3:목록보기  F4:로컬부트  F5:도구  F6:확장메뉴",
+    "VTLANG_STR_HOTKEY_LIST": "번역: 비너스걸 L:언어  F1:도움말  F2:찾아보기  F3:목록보기  F4:로컬부팅  F5:도구  F6:확장메뉴",
+    "VTLANG_STR_HOTKEY_TREE": "번역: 비너스걸 L:언어  F1:도움말  F2:찾아보기  F3:목록보기  F4:로컬부팅  F5:도구  F6:확장메뉴",
     "VTLANG_RETURN_PREVIOUS": "이전 메뉴로 돌아가기 [Esc]",
     "VTLANG_RETURN_PRV_NOESC": "이전 메뉴로 돌아가기",
-    
     "VTLANG_MENU_LANG": "메뉴 언어 선택",
-    
-    "VTLANG_LB_SBOOT_WINDOWS": "Windows 검색 및 부트",
-    "VTLANG_LB_SBOOT_G4D": "Grub4dos 검색 및 부트",
-    "VTLANG_LB_SBOOT_HDD1": "첫 번째 로컬 디스크 부트",
-    "VTLANG_LB_SBOOT_HDD2": "두 번째 로컬 디스크 부트",
-    "VTLANG_LB_SBOOT_HDD3": "세 번째 로컬 디스크 부트",
-    "VTLANG_LB_SBOOT_X64EFI": "BOOTX64.EFI 검색 및 부트",
-    "VTLANG_LB_SBOOT_IA32EFI": "BOOTIA32.EFI 검색 및 부트",
-    "VTLANG_LB_SBOOT_AA64EFI": "BOOTAA64.EFI 검색 및 부트",
-    "VTLANG_LB_SBOOT_XORBOOT": "xorboot 검색 및 부트",
-    
+    "VTLANG_LB_SBOOT_WINDOWS": "Windows 검색 및 부팅",
+    "VTLANG_LB_SBOOT_G4D": "Grub4dos 검색 및 부팅",
+    "VTLANG_LB_SBOOT_HDD1": "첫 번째 로컬 디스크 부팅",
+    "VTLANG_LB_SBOOT_HDD2": "두 번째 로컬 디스크 부팅",
+    "VTLANG_LB_SBOOT_HDD3": "세 번째 로컬 디스크 부팅",
+    "VTLANG_LB_SBOOT_X64EFI": "BOOTX64.EFI 검색 및 부팅",
+    "VTLANG_LB_SBOOT_IA32EFI": "BOOTIA32.EFI 검색 및 부팅",
+    "VTLANG_LB_SBOOT_AA64EFI": "BOOTAA64.EFI 검색 및 부팅",
+    "VTLANG_LB_SBOOT_XORBOOT": "xorboot 검색 및 부팅",
     "VTLANG_FILE_CHKSUM": "파일 체크섬",
     "VTLANG_CHKSUM_MD5_CALC": "md5sum 계산",
     "VTLANG_CHKSUM_SHA1_CALC": "sha1sum 계산",
@@ -27,26 +23,20 @@
     "VTLANG_CHKSUM_SHA1_CALC_CHK": "sha1sum 계산 및 확인",
     "VTLANG_CHKSUM_SHA256_CALC_CHK": "sha256sum 계산 및 확인",
     "VTLANG_CHKSUM_SHA512_CALC_CHK": "sha512sum 계산 및 확인",
-    
     "VTLANG_POWER": "전원",
-    "VTLANG_POWER_REBOOT": "다시 부트",
+    "VTLANG_POWER_REBOOT": "다시 부팅",
     "VTLANG_POWER_HALT": "끄기",
-    "VTLANG_POWER_BOOT_EFIFW": "EFI 설정으로 재부트",
-    
+    "VTLANG_POWER_BOOT_EFIFW": "EFI 설정으로 재부팅",
     "VTLANG_KEYBRD_LAYOUT": "키보드 레이아웃",
     "VTLANG_HWINFO": "하드웨어 정보",
-    
     "VTLANG_RESOLUTION_CFG": "해상도 구성",
     "VTLANG_SCREEN_MODE": "화면 표시 모드",
     "VTLANG_SCREEN_TEXT_MODE": "강제 텍스트 모드",
     "VTLANG_SCREEN_GUI_MODE": "강제 그래픽 모드",
-    
     "VTLANG_THEME_SELECT": "테마 선택",
-    
     "VTLANG_UEFI_UTIL": "Ventoy UEFI 유틸리티",
     "VTLANG_UTIL_SHOW_EFI_DRV": "EFI 드라이버 표시",
     "VTLANG_UTIL_FIX_BLINIT_FAIL": "Windows 초기화 라이브러리 오류 복구",
-    
     "VTLANG_JSON_CHK_JSON": "플러그인 json 구성 확인 (ventoy.json)",
     "VTLANG_JSON_CHK_CONTROL": "전역 제어 플러그인 구성 확인",
     "VTLANG_JSON_CHK_THEME": "테마 플러그인 구성 확인",
@@ -62,32 +52,24 @@
     "VTLANG_JSON_CHK_CONF_REPLACE": "부팅 구성 대체 플러그인 구성 확인",
     "VTLANG_JSON_CHK_DUD": "드라이버 디스크 업데이트 플러그인 구성 확인",
     "VTLANG_JSON_CHK_PASSWORD": "암호 플러그인 구성 확인",
-    
-    "VTLANG_NORMAL_MODE": "정상 모드로 부트",
-    "VTLANG_WIMBOOT_MODE": "wimboot 모드로 부트",
+    "VTLANG_NORMAL_MODE": "정상 모드로 부팅",
+    "VTLANG_WIMBOOT_MODE": "wimboot 모드로 부팅",
     "VTLANG_GRUB2_MODE": "grub2 모드로 부팅",
-    "VTLANG_MEMDISK_MODE": "memdisk 모드로 부트",
-    
+    "VTLANG_MEMDISK_MODE": "memdisk 모드로 부팅",
     "VTLANG_RET_TO_LISTVIEW": "목록 보기로 돌아가기",
     "VTLANG_RET_TO_TREEVIEW": "트리 보기로 돌아가기",
-    
-    "VTLANG_NO_AUTOINS_SCRIPT": "자동 설치 템플릿 없이 부트",
+    "VTLANG_NO_AUTOINS_SCRIPT": "자동 설치 템플릿 없이 부팅",
     "VTLANG_AUTOINS_USE": "부팅 대상",
-    
-    "VTLANG_NO_PERSIST": "지속성 없는 부트",
-    "VTLANG_PERSIST_USE": "부트 대상",
-    
+    "VTLANG_NO_PERSIST": "지속성 없는 부팅",
+    "VTLANG_PERSIST_USE": "부팅 대상",
     "VTLANG_BROWER_RETURN": "돌아가기",
-    
     "VTLANG_ENTER_EXIT": "Enter 키를 눌러 종료",
     "VTLANG_ENTER_REBOOT": "Enter 키를 눌러 재부팅",
     "VTLANG_ENTER_CONTINUE": "계속하려면 Enter 키를 누르십시오",
-    
     "VTLANG_CTRL_TEMP_SET": "임시 제어 설정",
     "VTLANG_WIN11_BYPASS_CHECK": "Windows 11을 설치할 때 우회 점검",
     "VTLANG_WIN11_BYPASS_NRO": "Windows 11 설치 시 온라인 계정 요구 사항 우회",
-    "VTLANG_LINUX_REMOUNT": "Linux 부트 후 Ventoy 파티션 마운트",
-    "VTLANG_SECONDARY_BOOT_MENU": "보조 부트 메뉴 표시",
-    
+    "VTLANG_LINUX_REMOUNT": "Linux 부팅 후 Ventoy 파티션 마운트",
+    "VTLANG_SECONDARY_BOOT_MENU": "보조 부팅 메뉴 표시",
     "MENU_STR_XXX": ""
 }


### PR DESCRIPTION
Changed the word "boot" to be spelled "부팅" rather than "부트" in the general context.

일반적인 맥락에서 단어 "boot"는 부트보다 부팅로 표기되므로 변경하였습니다.