### PR TITLE
Environment typos

### DIFF
--- a/DMSETUP/build.txt
+++ b/DMSETUP/build.txt
@@ -5,7 +5,7 @@ use an old version of dmsetup
 http://vault.centos.org/5.3/os/SRPMS/device-mapper-1.02.28-2.el5.src.rpm
 https://www.fefe.de/dietlibc/dietlibc-0.34.tar.xz
 
-======== Build Envrioment ======== 
+======== Build Environment ======== 
 build for 32bit, static linked with dietlibc
 1. install centos 6.10 i386 with CentOS-6.10-i386-bin-DVD1.iso
 2. yum install gcc kernel-devel package

--- a/DOC/BuildVentoyFromSource.txt
+++ b/DOC/BuildVentoyFromSource.txt
@@ -1,8 +1,8 @@
 
 ==========================================
-1. Compile Enviroment
+1. Compile Environment
 ==========================================
-    My build envrioment is CentOS 7.8 x86_64. So here I first explain how to create the build environment from scratch.
+    My build environment is CentOS 7.8 x86_64. So here I first explain how to create the build environment from scratch.
     Because Ventoy is based on many open source projects, so the environment is important. I suggest you test it on a virtual machine firstly.
 
 1.1 Install CentOS 7.8
@@ -54,7 +54,7 @@
     mv /opt/output /opt/mips64el-linux-musl-gcc730
     
 
-2.4 Set PATH envrioment
+2.4 Set PATH environment
     export PATH=$PATH:/opt/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu/bin:/opt/aarch64--uclibc--stable-2020.08-1/bin:/opt/mips64el-linux-musl-gcc730/bin
     better to add this line to /root/.bashrc and relogin as root
 

--- a/INSTALL/docker_ci_build.sh
+++ b/INSTALL/docker_ci_build.sh
@@ -3,7 +3,7 @@
 VTOY_PATH=$PWD/..
 
 date +"%Y/%m/%d %H:%M:%S"
-echo downloading envrionment ...
+echo downloading environment ...
 
 wget -q -P $VTOY_PATH/DOC/ https://github.com/ventoy/vtoytoolchain/releases/download/1.0/dietlibc-0.34.tar.xz
 wget -q -P $VTOY_PATH/DOC/ https://github.com/ventoy/vtoytoolchain/releases/download/1.0/musl-1.2.1.tar.gz
@@ -14,6 +14,6 @@ wget -q -P /opt/ https://github.com/ventoy/vtoytoolchain/releases/download/1.0/a
 wget -q -P /opt/ https://github.com/ventoy/vtoytoolchain/releases/download/1.0/mips-loongson-gcc7.3-2019.06-29-linux-gnu.tar.gz
 
 date +"%Y/%m/%d %H:%M:%S"
-echo downloading envrionment finish...
+echo downloading environment finish...
 
 sh all_in_one.sh CI

--- a/ZSTD/build.txt
+++ b/ZSTD/build.txt
@@ -4,7 +4,7 @@ Build a static linked, small zstdcat tool
 use an old version of zstd
 https://codeload.github.com/facebook/zstd/zip/v1.0.0
 
-======== Build Envrioment ======== 
+======== Build Environment ======== 
 build for 32bit, static linked with dietlibc
 1. install centos 6.10 i386 with CentOS-6.10-i386-bin-DVD1.iso
 2. yum install gcc gettext gettext-devel


### PR DESCRIPTION
The word environment is misspelled at multiple spots