### PR TITLE
Update ventoy-hook.sh for MX Linux

### DIFF
--- a/IMG/cpio/ventoy/hook/debian/ventoy-hook.sh
+++ b/IMG/cpio/ventoy/hook/debian/ventoy-hook.sh
@@ -26,6 +26,10 @@ ventoy_get_debian_distro() {
         if $EGREP -q "ID=.*antix|ID=.*mx" /etc/initrd-release; then
             echo 'antix'; return
         fi
+    elif [ -e /etc/initrd_release ]; then
+        if $EGREP -q "ID=.*antix|ID=.*mx" /etc/initrd_release; then
+            echo 'antix'; return
+        fi
     fi
     
     if [ -e /DISTRO_SPECS ]; then


### PR DESCRIPTION
due to a systemd issue, we had to rename initrd-release to initrd_release. depending on version, either file may exist, but not both.  antiX still uses intrd-release since they do not use systemd.  MX and AV Linux use intrd_release to get around a startup problem with systemd.