### PR TITLE
Correct EFI chainloader image device path

### DIFF
--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/loader/efi/chainloader.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/loader/efi/chainloader.c
@@ -229,10 +229,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
   if (! file)
     goto fail;
 
-  /* Get the root device's device path.  */
-  dev = grub_device_open (0);
-  if (! dev)
-    goto fail;
+  dev = file->device;
 
   if (dev->disk)
     dev_handle = grub_efidisk_get_device_handle (dev->disk);
@@ -257,15 +254,12 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
   if (dev_handle)
     dp = grub_efi_get_device_path (dev_handle);
 
-  if (! dp)
+  if (dp != NULL)
     {
-      grub_error (GRUB_ERR_BAD_DEVICE, "not a valid root device");
-      goto fail;
+      file_path = make_file_path (dp, filename);
+      if (! file_path)
+        goto fail;
     }
-
-  file_path = make_file_path (dp, filename);
-  if (! file_path)
-    goto fail;
 
   //grub_printf ("file path: ");
   //grub_efi_print_device_path (file_path);
@@ -390,15 +384,11 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
     }
 
   grub_file_close (file);
-  grub_device_close (dev);
 
   grub_loader_set (grub_chainloader_boot, grub_chainloader_unload, 0);
   return 0;
 
  fail:
-
-  if (dev)
-    grub_device_close (dev);
 
   if (file)
     grub_file_close (file);


### PR DESCRIPTION
使用 `chainloader` 加载 EFI 文件时，`DevicePath` 中的磁盘分区应当设为文件所在的磁盘分区，而不是 `$root` 分区。
另外，根据 UEFI Spec，`DevicePath` 可以为空。
![Snipaste_2023-05-19_21-58-41](https://github.com/ventoy/Ventoy/assets/10670106/998f5f6d-c571-41a3-b2e2-8ed24fb2d075)


http://bbs.wuyou.net/forum.php?mod=redirect&goto=findpost&ptid=423940&pid=4923455

> 大佬，请教一下我拿 ventoy 的 grub2.04 通过 chainloader 引导 ntloader，会报错：Could not open simple file system。其中，ntloader 和 initlz1 在 Fat32 分区，vhd 镜像在 ntfs 分区。
> 我的引导指令如下：
> set root=(hd1, 3)
> probe -u --set=dev_uuid (hd1,3)
> chainloader (hd1,1)/ntloader initrd=/initrd.lz1 uuid=${dev_uuid} file=/win7.vhd
> boot
> 其中，(hd1,3) 为 存放 vhd 镜像的 ntfs 分区，(hd1,1) 为存放 ntloader 和 initrd.lz1 的 fat32 分区
> 使用该指令，在 Ubuntu18.06（grub2.04) 和 ubuntu 22.04(grub2.06) 上都可以正常引导，但是在 ventoy 中就报错了。
> 是不是需要打什么 patch 或者做什么修改呢？

必须在 `chainloader` 之前执行 `set root=(hd1, 1)` ，这有点让人迷惑。
Ubuntu, RedHat 等主流发行版的 GRUB 2 都已经修复了这个问题。