### PR TITLE
Hide VTOYEFI partition by marking as `diag`

### DIFF
--- a/INSTALL/tool/ventoy_lib.sh
+++ b/INSTALL/tool/ventoy_lib.sh
@@ -436,7 +436,7 @@ format_ventoy_disk_gpt() {
     vtdebug "format disk by parted ..."
     
     if [ "$TOOLDIR" != "aarch64" ]; then
-        vt_set_efi_type="set 2 msftdata on"
+        vt_set_efi_type="set 2 diag on"
     fi    
     
     parted -a none --script $DISK \


### PR DESCRIPTION
The VTOYEFI partition is flagged as `msftdata`. This causes the VTOYEFI partition to show up on XFCE desktop like this:

![image](https://github.com/ventoy/Ventoy/assets/30787981/da79bf39-ab5d-4430-902b-643bf5765eb5)

This patch hides the VTOYEFI partition by marking it as `diag` instead. The created Ventoy USB stick has been tested and works well. No issues with booting, and VTOYEFI partition is hidden on the XFCE desktop.