### PR TITLE
Make type of password input fields in plugson: type=password

### DIFF
--- a/Plugson/www/plugson_password.html
+++ b/Plugson/www/plugson_password.html
@@ -164,7 +164,7 @@
   }
 
   function CommonPasswordEntry(tbl, name, cn, en) {
-    var tr = '<tr><td>'+name+'</td><td><input type="text" class="form-control" id="id_'+name+'" disabled="disabled"/></td>' +
+    var tr = '<tr><td>'+name+'</td><td><input type="password" class="form-control" id="id_'+name+'" disabled="disabled"/></td>' +
       '<td><button id="id_btn_set_'+name+'" class="btn btn-primary btn-sm btn-add CommPwdSetBtn"><span class="fa fa-edit"></span><span id="id_span_edit"></span></button>&nbsp;&nbsp;' +
       '<button id="id_btn_clr_'+name+'" class="btn btn-danger btn-sm btn-del CommPwdClearBtn"><span class="fa fa-trash"></span><span id="id_span_clear"></span></button></td>' +
       '<td><span id="id_span_desc_cn">' + cn + '</span>' +


### PR DESCRIPTION
#  proposal
In Ventoy Plugson -> Password Plugin, you can set a password. That HTML input field has `type="text"`.
I would propose changing it to `type="password"` because:

- other people will or can not see the password
- a password field should be `type="password"`
- the browser will not save the input field, therefore not exposing your password (which would currently happen)

# clarification:
## this is the current status:
![image](https://github.com/ventoy/Ventoy/assets/38194372/3a6d4a03-c097-4714-8892-304d37e60f96)
## (browser saves `type=text` input fields, therefore exposing my password:
![image](https://github.com/ventoy/Ventoy/assets/38194372/d84bf436-aa1b-49d2-b86e-cc1ef2d25cbe)


## after my change is implemented:
![image](https://github.com/ventoy/Ventoy/assets/38194372/ffa72f3d-7650-40de-a5ed-a7cd13a82d14)