### PR TITLE
fix Synchronous Exception on some arm cpus

### DIFF
--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/kern/file.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/kern/file.c
@@ -342,10 +342,12 @@ grub_file_read (grub_file_t file, void *buf, grub_size_t len)
   if (len == 0)
     return 0;
 
-  if (grub_strncmp(file->name, GRUB_MEMFILE_MEM, grub_strlen(GRUB_MEMFILE_MEM)) == 0) {
+  if (file->name) {
+    if (grub_strncmp(file->name, GRUB_MEMFILE_MEM, grub_strlen(GRUB_MEMFILE_MEM)) == 0) {
       grub_memcpy(buf, (grub_uint8_t *)(file->data) + file->offset, len);
       file->offset += len;
       return len;
+    }
   }
   
   read_hook = file->read_hook;


### PR DESCRIPTION
Issues maybe related: #1188 #1658 #2458 
I'm testing on a rk3588 sbc with [an edk2 firmware](https://github.com/edk2-porting/edk2-rk3588).
I encountered the same issue https://github.com/edk2-porting/edk2-rk3588/issues/6 as above.
After a lot of `grub_printf` I find that `file->name` here is not initilized by [grub_bufio_open](https://github.com/ventoy/Ventoy/blob/master/GRUB2/MOD_SRC/grub-2.04/grub-core/normal/main.c#L136). And my rk3588 will get `Synchronous Exception` when grub_strncmp runs with null`file->name`. So I just skip it when there is no `file->name`.