### PR TITLE
Update localboot.cfg to add exit

### DIFF
--- a/INSTALL/grub/localboot.cfg
+++ b/INSTALL/grub/localboot.cfg
@@ -217,6 +217,11 @@ else
 
 fi
 
+menuentry "Exit and continue boot process" {
+    echo "handing back to firmware for next boot option ..."
+    exit
+}
+
 menuentry "$VTLANG_RETURN_PREVIOUS" --class=vtoyret VTOY_RET {
     echo "Return ..."
 }


### PR DESCRIPTION
adds an exit entry to local boot which can hand the bood process back to the systems firmware and thereby help to boot from other devices without reboot

i tested it and it worked here in uefi and bios mode, but on some firmwares you have to do it twice cause uefi mode hands in to bios mode, but that can help to if you wish to switch to that mode and your firmware has no selection for the mode and handles one usb device as one entry...

see also issue #2620 