### PR TITLE
Bugfix VentoyWorker.sh - mount detection false-positive

### DIFF
--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -137,7 +137,7 @@ fi
 #check mountpoint
 check_umount_disk "$DISK"
 
-if grep "$DISK" /proc/mounts; then
+if grep -w "$DISK" /proc/mounts; then
     vterr "$DISK is already mounted, please umount it first!"
     exit 1
 fi


### PR DESCRIPTION
Need to match whole word, or e.g. /dev/loop12 would match, when trying to install to /dev/loop1