### PR TITLE
Adding root user check to ExtendPersistentImg (as in CreatePersistentImg)

### DIFF
--- a/INSTALL/ExtendPersistentImg.sh
+++ b/INSTALL/ExtendPersistentImg.sh
@@ -4,8 +4,9 @@ print_usage() {
     echo 'Usage:  ExtendPersistentImg.sh file size'
     echo '   file   persistent dat file'
     echo '   size   extend size in MB'
-    echo 'Example:'
-    echo '   sh ExtendPersistentImg.sh ubuntu.dat 2048'
+    echo 'Examples:'
+    echo '   sh ExtendPersistentImg.sh ubuntu.dat 2048 - This command would extend ubuntu.dat by 2048MB (2GB)'
+    echo '   sh ExtendPersistentImg.sh ubuntu.dat -2048 - This command reduces ubuntu.dat by 2048MB (-2GB)'
     echo ''
 }
 
@@ -33,6 +34,11 @@ fi
 
 file=$1
 size=$2
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
 
 if [ ! -f "$file" ]; then
     echo "$file not exist."

--- a/INSTALL/ExtendPersistentImg.sh
+++ b/INSTALL/ExtendPersistentImg.sh
@@ -20,6 +20,11 @@ if [ -z "$2" ]; then
     exit 1
 fi
 
+uid=$(id -u)
+if [ $uid -ne 0 ]; then
+    print_err "Please use sudo or run the script as root."
+    exit 1
+fi
 
 if [ "$1" = "__vbash__" ]; then
     shift
@@ -34,11 +39,6 @@ fi
 
 file=$1
 size=$2
-
-if [ "$EUID" -ne 0 ]
-  then echo "Please run as root"
-  exit
-fi
 
 if [ ! -f "$file" ]; then
     echo "$file not exist."


### PR DESCRIPTION
Today I tried to change size of my existing persistent image file and after couple of minutes later script finished with an error I understatnd that I didn't execute script with root permission. So I decided to add check to prevent other users from doing that.

Thanks for Ventoy!