### PR TITLE
Solved passphrase error

### DIFF
--- a/INSTALL/CreatePersistentImg.sh
+++ b/INSTALL/CreatePersistentImg.sh
@@ -108,8 +108,8 @@ freeloop=$(losetup -f)
 losetup $freeloop "$outputfile"
 
 if [ ! -z "$passphrase" ]; then
-    printf "$passphrase" | cryptsetup -q --verbose luksFormat $freeloop -
-    printf "$passphrase" | cryptsetup -q --verbose luksOpen $freeloop persist_decrypted -
+    printf -- "$passphrase" | cryptsetup -q --verbose luksFormat $freeloop -
+    printf -- "$passphrase" | cryptsetup -q --verbose luksOpen $freeloop persist_decrypted -
     _freeloop=$freeloop
     freeloop="/dev/mapper/persist_decrypted"
 fi


### PR DESCRIPTION
Solved 'Illegal option' error when passphrase starts with hyphen.

e.g. the error occurs with the input `-X.pass`
```bash
export passphrase="-X.pass"
printf "$passphrase"
# Output:
# script.sh: line 2: printf: -X: invalid option
# printf: usage: printf [-v var] format [arguments]
```

With the double hyphen the `printf` works as expected
```sh
export passphrase="-X.pass"
printf -- "$passphrase"
# Output: -X.pass
```