### PR TITLE
Improve EDK2 build process script for simplicity and reliability

### DIFF
--- a/EDK2/buildedk.sh
+++ b/EDK2/buildedk.sh
@@ -1,21 +1,25 @@
 #!/bin/sh
 
+# Remove old EDK2 directory and unzip new one
 rm -rf edk2-edk2-stable201911
-
 unzip edk2-edk2-stable201911.zip > /dev/null
 
-/bin/cp -a ./edk2_mod/edk2-edk2-stable201911  ./
+# Copy modified EDK2 files
+/bin/cp -a ./edk2_mod/edk2-edk2-stable201911 ./
 
-cd edk2-edk2-stable201911
+# Build BaseTools
+cd edk2-edk2-stable201911 || exit 1
 make -j 4 -C BaseTools/
 cd ..
 
-echo '======== build EDK2 for i386-efi ==============='
-sh ./build.sh ia32 || exit 1
+# Function to build EDK2 for different architectures
+build_edk2() {
+    local arch=$1
+    echo "======== build EDK2 for $arch-efi ==============="
+    sh ./build.sh "$arch" || exit 1
+}
 
-echo '======== build EDK2 for arm64-efi ==============='
-sh ./build.sh aa64 || exit 1
-
-echo '======== build EDK2 for x86_64-efi ==============='
-sh ./build.sh      || exit 1
-
+# Build for different architectures
+build_edk2 "ia32"
+build_edk2 "aa64"
+build_edk2 "" # default to x86_64


### PR DESCRIPTION
- Update script to remove the existing EDK2 directory and unzip the new one, ensuring a clean start for the build process.
- Add a check to exit the script if changing to the EDK2 directory fails, enhancing the robustness of the script.
- Introduce a function `build_edk2` to streamline the building of EDK2 for different architectures (i386-efi, arm64-efi, and x86_64-efi). This function takes the architecture as an argument and executes the corresponding build command.
- Replace repetitive build commands with calls to `build_edk2` function, reducing redundancy and improving the readability of the script.

**Note:**
I did not test this refactored code. Merge only after testing.