### PR TITLE
Refine script for creating Ventoy EFI boot image

### DIFF
--- a/EfiISO/mkefiiso.sh
+++ b/EfiISO/mkefiiso.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
 
+# Remove previous Ventoy EFI boot image
 rm -f ventoy_efiboot.img.*
 
-cd ISO
-mkisofs -R -D -sysid VENTOY -V VENTOY -P "longpanda admin@ventoy.net" -p 'https://www.ventoy.net' -o ../ventoy_efiboot.img ./ 
-cd ..
+# Create new ISO in the ISO directory
+(
+    cd ISO || exit 1
+    mkisofs -R -D -sysid VENTOY -V VENTOY \
+            -P "longpanda admin@ventoy.net" \
+            -p 'https://www.ventoy.net' \
+            -o ../ventoy_efiboot.img ./ 
+)
 
+# Compress the new EFI boot image
 xz --check=crc32 ventoy_efiboot.img
 
+# Replace the existing compressed EFI boot image in the INSTALL directory
 rm -f ../INSTALL/ventoy/ventoy_efiboot.img.xz
 cp -a ventoy_efiboot.img.xz ../INSTALL/ventoy/
-


### PR DESCRIPTION
- Add a safeguard to exit the script if changing to the ISO directory fails, ensuring robustness in the script execution.
- Format the `mkisofs` command for better readability by breaking it into multiple lines. This enhances the maintainability of the script.
- Simplify the process of replacing the existing compressed EFI boot image in the INSTALL directory by removing the old file first and then copying the new one.

**Note:**
I did not test this refactored code. Merge only after testing.