### PR TITLE
Refactor vtoycli compilation script for enhanced clarity and modularity

### DIFF
--- a/vtoycli/build.sh
+++ b/vtoycli/build.sh
@@ -1,32 +1,37 @@
 #!/bin/sh
 
-rm -f vtoycli_64
-rm -f vtoycli_32
-rm -f vtoycli_aa64
-rm -f vtoycli_m64e
-
+# Define source files
 SRCS="vtoycli.c vtoyfat.c vtoygpt.c crc32.c partresize.c"
 
-gcc -specs "/usr/local/musl/lib/musl-gcc.specs" -Os -static -D_FILE_OFFSET_BITS=64 $SRCS -Ifat_io_lib/include fat_io_lib/lib/libfat_io_64.a -o vtoycli_64
+# Function to compile for different architectures
+compile_vtoycli() {
+    local compiler=$1
+    local lib=$2
+    local output=$3
+    local extra_flags=$4
 
-/opt/diet32/bin/diet -Os gcc -D_FILE_OFFSET_BITS=64 -m32 $SRCS -Ifat_io_lib/include fat_io_lib/lib/libfat_io_32.a -o vtoycli_32
+    $compiler $extra_flags -D_FILE_OFFSET_BITS=64 $SRCS -Ifat_io_lib/include $lib -o $output
+}
 
+# Remove old binaries
+rm -f vtoycli_64 vtoycli_32 vtoycli_aa64 vtoycli_m64e
 
-#gcc -O2 -D_FILE_OFFSET_BITS=64 $SRCS -Ifat_io_lib/include fat_io_lib/lib/libfat_io_64.a -o vtoycli_64
-#gcc -m32 -O2 -D_FILE_OFFSET_BITS=64 $SRCS -Ifat_io_lib/include fat_io_lib/lib/libfat_io_32.a -o vtoycli_32
+# Compile for different architectures
+compile_vtoycli "gcc -specs /usr/local/musl/lib/musl-gcc.specs -Os -static" "fat_io_lib/lib/libfat_io_64.a" "vtoycli_64"
+compile_vtoycli "/opt/diet32/bin/diet -Os gcc -m32" "fat_io_lib/lib/libfat_io_32.a" "vtoycli_32"
+compile_vtoycli "aarch64-buildroot-linux-uclibc-gcc -static -O2" "fat_io_lib/lib/libfat_io_aa64.a" "vtoycli_aa64"
+compile_vtoycli "mips64el-linux-musl-gcc -mips64r2 -mabi=64 -static -O2" "fat_io_lib/lib/libfat_io_m64e.a" "vtoycli_m64e"
 
-aarch64-buildroot-linux-uclibc-gcc -static -O2 -D_FILE_OFFSET_BITS=64 $SRCS -Ifat_io_lib/include fat_io_lib/lib/libfat_io_aa64.a -o vtoycli_aa64
-mips64el-linux-musl-gcc -mips64r2 -mabi=64 -static -O2 -D_FILE_OFFSET_BITS=64 $SRCS -Ifat_io_lib/include fat_io_lib/lib/libfat_io_m64e.a -o vtoycli_m64e
-
-
+# Check if all binaries are created and move them
 if [ -e vtoycli_64 ] && [ -e vtoycli_32 ] && [ -e vtoycli_aa64 ] && [ -e vtoycli_m64e ]; then
-    echo -e "\n===== success $name =======\n"
+    echo -e "\n===== success =======\n"
     
-    strip --strip-all vtoycli_32
-    strip --strip-all vtoycli_64
+    # Strip all binaries
+    strip --strip-all vtoycli_32 vtoycli_64
     aarch64-buildroot-linux-uclibc-strip --strip-all vtoycli_aa64
     mips64el-linux-musl-strip --strip-all vtoycli_m64e
-    
+
+    # Move binaries to respective directories
     [ -d ../INSTALL/tool/i386/ ] && mv vtoycli_32 ../INSTALL/tool/i386/vtoycli
     [ -d ../INSTALL/tool/x86_64/ ] && mv vtoycli_64 ../INSTALL/tool/x86_64/vtoycli
     [ -d ../INSTALL/tool/aarch64/ ] && mv vtoycli_aa64 ../INSTALL/tool/aarch64/vtoycli


### PR DESCRIPTION
- Introduce a `compile_vtoycli` function to centralize the compilation logic for different architectures. This function accepts the compiler, library, output binary name, and extra flags as arguments.
- Simplify removal of old binaries by consolidating `rm` commands into a single line.
- Utilize the `compile_vtoycli` function to compile the `vtoycli` tool for x64, ia32, aarch64, and mips64el architectures.
- Improve the check for successful compilation by verifying the existence of all expected binaries before proceeding to strip and move them.
- Streamline the stripping and moving of binaries to their respective directories, enhancing the script's readability and maintainability.

**Note:**
I did not test this refactored code. Merge only after testing.