### PR TITLE
Made CreatePersistentImg.sh non-interactive.

### DIFF
--- a/INSTALL/CreatePersistentImg.sh
+++ b/INSTALL/CreatePersistentImg.sh
@@ -114,7 +114,7 @@ if [ ! -z "$passphrase" ]; then
     freeloop="/dev/mapper/persist_decrypted"
 fi
 
-mkfs -t $fstype $fsopt -L $label $freeloop 
+yes | mkfs -t $fstype $fsopt -L $label $freeloop
 
 sync
 


### PR DESCRIPTION
mkfs part was asking Y/N whether I want to create a FS in persistence.dat file. This should be automatically answered yes as user confirms it already by running this script.