### PR TITLE
fix SystemRescue 11.02 boot

### DIFF
--- a/IMG/cpio/ventoy/init_chain
+++ b/IMG/cpio/ventoy/init_chain
@@ -73,8 +73,10 @@ ventoy_unpack_initramfs() {
     for vtx in '1F8B zcat' '1F9E zcat' '425A bzcat' '5D00 lzcat' 'FD37 xzcat' '894C lzopcat' '0221 lz4cat' '28B5 zstdcat' '3037 cat' '4C5A lunzip -c'; do
         if [ "${vtx:0:4}" = "${vtmagic:0:4}" ]; then
             echo "vtx=$vtx" >> $VTLOG
-            dd if=$vtfile skip=$vtskip of=$vttmp iflag=skip_bytes status=none
-            mv $vttmp $vtfile                  
+            if [ $vtskip -ne 0 ]; then
+                dd if=$vtfile skip=$vtskip of=$vttmp iflag=skip_bytes status=none
+                mv $vttmp $vtfile               
+            fi   
             if [ "${vtx:5}" = "xzcat" ]; then
                 rm -f $VTOY_PATH/xzlog
                 ${vtx:5} $vtfile 2> $VTOY_PATH/xzlog | (cpio -idmu 2>>$VTLOG; cat > $vttmp)

--- a/IMG/cpio/ventoy/init_chain
+++ b/IMG/cpio/ventoy/init_chain
@@ -72,26 +72,24 @@ ventoy_unpack_initramfs() {
     
     for vtx in '1F8B zcat' '1F9E zcat' '425A bzcat' '5D00 lzcat' 'FD37 xzcat' '894C lzopcat' '0221 lz4cat' '28B5 zstdcat' '3037 cat' '4C5A lunzip -c'; do
         if [ "${vtx:0:4}" = "${vtmagic:0:4}" ]; then
-            echo "vtx=$vtx" >> $VTLOG            
-            if [ $vtskip -eq 0 ]; then            
-                if [ "${vtx:5}" = "xzcat" ]; then
+            echo "vtx=$vtx" >> $VTLOG
+            dd if=$vtfile skip=$vtskip of=$vttmp iflag=skip_bytes status=none
+            mv $vttmp $vtfile                  
+            if [ "${vtx:5}" = "xzcat" ]; then
+                rm -f $VTOY_PATH/xzlog
+                ${vtx:5} $vtfile 2> $VTOY_PATH/xzlog | (cpio -idmu 2>>$VTLOG; cat > $vttmp)
+                if grep -q 'corrupted data' $VTOY_PATH/xzlog; then
+                    echo 'xzcat failed, now try xzminidec...' >> $VTLOG                        
                     rm -f $VTOY_PATH/xzlog
-                    ${vtx:5} $vtfile 2> $VTOY_PATH/xzlog | (cpio -idmu 2>>$VTLOG; cat > $vttmp)
-                    if grep -q 'corrupted data' $VTOY_PATH/xzlog; then
-                        echo 'xzcat failed, now try xzminidec...' >> $VTLOG                        
-                        rm -f $VTOY_PATH/xzlog
-                        cat $vtfile | xzminidec 2> $VTOY_PATH/xzlog | (cpio -idmu 2>>$VTLOG; cat > $vttmp)
+                    cat $vtfile | xzminidec 2> $VTOY_PATH/xzlog | (cpio -idmu 2>>$VTLOG; cat > $vttmp)
 
-                        if grep -q 'limit' $VTOY_PATH/xzlog; then                    
-                            echo 'xzminidec failed, now try xzcat_musl ...' >> $VTLOG  
-                            xzcat_musl $vtfile | (cpio -idmu 2>>$VTLOG; cat > $vttmp)
-                        fi
+                    if grep -q 'limit' $VTOY_PATH/xzlog; then                    
+                        echo 'xzminidec failed, now try xzcat_musl ...' >> $VTLOG  
+                        xzcat_musl $vtfile | (cpio -idmu 2>>$VTLOG; cat > $vttmp)
                     fi
-                else
-                    ${vtx:5} $vtfile | (cpio -idmu 2>>$VTLOG; cat > $vttmp)
                 fi
             else
-                dd if=$vtfile skip=$vtskip iflag=skip_bytes status=none | ${vtx:5} | (cpio -idmu 2>>$VTLOG; cat > $vttmp)
+                ${vtx:5} $vtfile | (cpio -idmu 2>>$VTLOG; cat > $vttmp)
             fi
             break
         fi


### PR DESCRIPTION
Fix #2958

**Cause:** xzcat is failing on ventoy_unpack_initramfs() when $vtskip != 0:
https://github.com/ventoy/Ventoy/blob/b11c38779d319fc6dde97e5e9a45b26e68ddd6e1/IMG/cpio/ventoy/init_chain#L93-L95

It's not attempting xzminidec and xzcat_musl, unlike the case where $vtskip == 0, 
https://github.com/ventoy/Ventoy/blob/b11c38779d319fc6dde97e5e9a45b26e68ddd6e1/IMG/cpio/ventoy/init_chain#L76-L89

