### PR TITLE
Clean up block device detection logic

### DIFF
--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -312,22 +312,18 @@ if [ "$MODE" = "install" -a -z "$NONDESTRUCTIVE" ]; then
 
     #format part1
     wait_and_create_part ${PART1} ${PART2}    
-    if [ -b ${PART1} ]; then
-        vtinfo "Format partition 1 ${PART1} ..."
+    vtinfo "Format partition 1 ${PART1}..."
+    mkexfatfs -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
+    if [ $? -ne 0 ]; then
+        vtwarn "mkexfatfs failed; retrying..."
         mkexfatfs -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
         if [ $? -ne 0 ]; then
-            echo "mkexfatfs failed, now retry..."
-            mkexfatfs -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
-            if [ $? -ne 0 ]; then
-                echo "######### mkexfatfs failed, exit ########"
-                exit 1
-            fi
-        else
-            echo "mkexfatfs success"
-        fi        
+            vterr "######## mkexfatfs failed, exit ########"
+            exit 1
+        fi
     else
-        vterr "${PART1} NOT exist"
-    fi
+        vtinfo "mkexfatfs success"
+    fi        
 
     vtinfo "writing data to disk ..."
     dd status=none conv=fsync if=./boot/boot.img of=$DISK bs=1 count=446


### PR DESCRIPTION
From https://github.com/ventoy/Ventoy/issues/3174#issue-2940384521:

> - Having nested if statements in wait_and_create_part() corrupts the intended logic. If the first condition (for $vPART1) passes but the second (for $vPART2) fails, the else doesn't trigger, leading to missed waits, and then a missed sanity check at the end that allows execution to continue
> - Using ls | grep -q '^b' to check for block devices (again in wait_and_create_part()) is fragile: it's not uncommon for ls to be aliased or options set that may prevent 'b' from reliably being the first letter of the output for a valid block device. Also, the partitions are being checked for presence, then immediately checked again, and if they don't enumerate the second time then mknod is being called which could cause further device re-enumeration
> - The quick succession of having the partitions be altered and checked, sequentially and inconsistently due to the first point, is causing a race condition that allows execution to continue when it shouldn't.
> 
> I edited the code to use partprobe (provided by parted, which the project already depends on) to inform the kernel of any device changes, slowed the loop down and removed the mknod code, and it worked great afterwards.
>
> Interestingly, as happened in my case, if the device already had a exfat partition 1, from an old ventoy installation or prior use, that old fs signature can persist through the formatting process leading to weird effect. I was experiencing https://github.com/ventoy/Ventoy/issues/1133, on GPT and MBR, but after changing this logic, Windows 11 installation now works fine.

In the end I elected to not remove the `mknod` code as I figured that there may be a legitimate case where it's needed. However, in this PR I edit it to only be called if the partition fs nodes are not found after repeated kernel refreshing, and, after it runs, the device partitions are re-checked before continuing. If this succeeds then the process continues to `mkexfatfs`, and, if not, the user is advised to try re-inserting the USB or retrying with other ports/hardware.

I hope this PR is okay? It's my first to the project and I hope it's helpful in some way.

Closes #3174 