### PR TITLE
Basic support for porteuX boot

### DIFF
--- a/INSTALL/grub/grub.cfg
+++ b/INSTALL/grub/grub.cfg
@@ -406,6 +406,8 @@ function distro_specify_initrd_file_phase2 {
         vt_linux_specify_initrd_file /360Disk/initrd.gz
     elif [ -f (loop)/porteus/initrd.xz ]; then
         vt_linux_specify_initrd_file /porteus/initrd.xz
+    elif [ -f (loop)/porteux/initrd.zst ]; then
+        vt_linux_specify_initrd_file /porteux/initrd.zst
     elif [ -f (loop)/pyabr/boot/initrfs.img ]; then
         vt_linux_specify_initrd_file /pyabr/boot/initrfs.img
     elif [ -f (loop)/initrd0.img ]; then
@@ -856,6 +858,9 @@ function uefi_linux_menu_func {
                 set vtback_cfg_find=1
             elif [ -f (loop)/boot/syslinux/porteus.cfg ]; then
                 syslinux_configfile (loop)/boot/syslinux/porteus.cfg
+                set vtback_cfg_find=1
+            elif [ -f (loop)/boot/syslinux/porteux.cfg ]; then
+                syslinux_configfile (loop)/boot/syslinux/porteux.cfg
                 set vtback_cfg_find=1
             fi
         fi
@@ -1310,6 +1315,9 @@ function legacy_linux_menu_func {
                     set vtback_cfg_find=1
                 elif [ -f (loop)/boot/syslinux/porteus.cfg ]; then
                     syslinux_configfile (loop)/boot/syslinux/porteus.cfg
+                    set vtback_cfg_find=1
+                elif [ -f (loop)/boot/syslinux/porteux.cfg ]; then
+                    syslinux_configfile (loop)/boot/syslinux/porteux.cfg
                     set vtback_cfg_find=1
                 fi
             fi


### PR DESCRIPTION
PorteuX is very similar to Porteus. Here I just looked at the porteus configuration changes and added the option for porteuX. I have tested it booting in VirtualBox and it works well. I saw other places in the ventoy codebase where there were modifications for Porteus, so this might not support all of the same features, but at least it boots.
This relates to: https://github.com/ventoy/Ventoy/issues/2722