### PR TITLE
Check mkfs.vfat command

### DIFF
--- a/INSTALL/tool/ventoy_lib.sh
+++ b/INSTALL/tool/ventoy_lib.sh
@@ -67,6 +67,14 @@ check_tool_work_ok() {
         ventoy_false
         return
     fi
+
+    if mkfs.fat --help > /dev/null; then
+        vtdebug "mkfs.vfat test ok ..."
+    else
+        vtdebug "mkfs.vfat test fail ..."
+        ventoy_false
+        return
+    fi
     
     if vtoycli fat -T; then
         vtdebug "vtoycli fat test ok ..."


### PR DESCRIPTION
Some distributions don't come with mkfs.vfat by default, such as Arch Linux users should install [dosfstools](https://archlinux.org/packages/core/x86_64/dosfstools/) manually.