### PR TITLE
Fix the boot issue for Parted Magic

### DIFF
--- a/IMG/cpio/ventoy/ventoy_chain.sh
+++ b/IMG/cpio/ventoy/ventoy_chain.sh
@@ -52,6 +52,11 @@ ventoy_get_os_type() {
         fi
     fi
 
+    # Parted Magic
+    if [ -d /pmagic ]; then
+        echo 'pmagic'; return
+    fi
+
     # PrimeOS :
     if $GREP -q 'PrimeOS' /proc/version; then
         echo 'primeos'; return
@@ -235,10 +240,6 @@ ventoy_get_os_type() {
     
     if $GREP -q 'adelielinux' /proc/version; then
         echo 'adelie'; return
-    fi
-    
-    if $GREP -q 'pmagic' /proc/version; then
-        echo 'pmagic'; return
     fi
     
     if $GREP -q 'CDlinux' /proc/cmdline; then

--- a/IMG/cpio/ventoy/ventoy_loop.sh
+++ b/IMG/cpio/ventoy/ventoy_loop.sh
@@ -101,6 +101,11 @@ ventoy_get_os_type() {
         fi
     fi
 
+    # Parted Magic
+    if [ -d /pmagic ]; then
+        echo 'pmagic'; return
+    fi
+
     # rhel5/CentOS5 and all other distributions based on them
     if $GREP -q 'el5' /proc/version; then
         echo 'rhel5'; return
@@ -267,10 +272,6 @@ ventoy_get_os_type() {
     
     if $GREP -q 'adelielinux' /proc/version; then
         echo 'adelie'; return
-    fi
-    
-    if $GREP -q 'pmagic' /proc/version; then
-        echo 'pmagic'; return
     fi
     
     if $GREP -q 'CDlinux' /proc/cmdline; then


### PR DESCRIPTION
This should fix #3212.

The `/pmagic` directory exists at least as far as 2013_08_10. The change allows to boot the latest versions of Parted Magic that switched to Ubuntu kernel. Tested with 2014_08_14, 2020_05_20 (both pmagic kernel) and 2025_06_27 (Ubuntu kernel).