### PR TITLE
Add Flatpak support using UDisks2

### DIFF
--- a/LinuxGUI/README.md
+++ b/LinuxGUI/README.md
@@ -1,0 +1,12 @@
+# LinuxGUI UDisks2 + Flatpak
+This is a fork of Ventoy which uses UDisks2 as a backend for LinuxGUI, so it can run as a flatpak.
+
+## Development
+
+You can get started with
+
+```
+flatpak-builder --force-clean --user --install-deps-from=flathub --repo=repo --install output LinuxGUI/org.ventoy.VentoyGUI.yml
+```
+
+(See https://docs.flatpak.org/en/latest/first-build.html)

--- a/LinuxGUI/Ventoy2Disk/Core/ventoy_define.h
+++ b/LinuxGUI/Ventoy2Disk/Core/ventoy_define.h
@@ -20,6 +20,9 @@
 #ifndef __VENTOY_DEFINE_H__
 #define __VENTOY_DEFINE_H__
 
+#include <stdint.h>
+#include <udisks/udisks.h>
+
 #define MAX_DISK_NUM    256
 
 #define SIZE_1MB    1048576
@@ -124,27 +127,40 @@ typedef struct disk_ventoy_data
 }disk_ventoy_data;
 
 
+// typedef struct ventoy_disk
+// {
+//     char disk_name[32];   // sda
+//     char disk_path[64];   // /dev/sda
+
+//     char part1_name[32];   // sda1
+//     char part1_path[64];   // /dev/sda1
+//     char part2_name[32];   // sda2
+//     char part2_path[64];   // /dev/sda2
+
+//     char disk_model[256]; // Sandisk/Kingston ...
+//     char human_readable_size[32];
+
+//     int is4kn;
+//     int major;
+//     int minor;
+//     int type;
+//     int partstyle;
+//     uint64_t size_in_byte;
+
+//     disk_ventoy_data vtoydata;
+// }ventoy_disk;
+
 typedef struct ventoy_disk
 {
-    char disk_name[32];   // sda
-    char disk_path[64];   // /dev/sda
-
-    char part1_name[32];   // sda1
-    char part1_path[64];   // /dev/sda1
-    char part2_name[32];   // sda2
-    char part2_path[64];   // /dev/sda2
-
-    char disk_model[256]; // Sandisk/Kingston ...
+    UDisksObject *obj;
+    UDisksBlock *blockdev;
+    UDisksPartitionTable *table;
+    int is4kn; // Is 4k sector native?
     char human_readable_size[32];
-
-    int is4kn;
-    int major;
-    int minor;
-    int type;
-    int partstyle;
-    uint64_t size_in_byte;
-
     disk_ventoy_data vtoydata;
+    char disk_name[32];   // same as path, it is here for compatibility
+    char disk_path[32];   // /dev/sda
+    char disk_model[256]; // Sandisk/Kingston ...
 }ventoy_disk;
 
 #pragma pack(1)

--- a/LinuxGUI/Ventoy2Disk/Core/ventoy_define.h
+++ b/LinuxGUI/Ventoy2Disk/Core/ventoy_define.h
@@ -161,6 +161,7 @@ typedef struct ventoy_disk
     char disk_name[32];   // same as path, it is here for compatibility
     char disk_path[32];   // /dev/sda
     char disk_model[256]; // Sandisk/Kingston ...
+    int hint_ignore;
 }ventoy_disk;
 
 #pragma pack(1)

--- a/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.c
+++ b/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.c
@@ -212,7 +212,7 @@ int ventoy_is_disk_4k_native(ventoy_disk *disk)
         rc = 1;
     }
 
-    vdebug("is 4k native disk <%s> <%d>\n", disk, rc);    
+    vdebug("is 4k native disk <%s> <%d>\n", disk->disk_model, rc);
     return rc;
 }
 
@@ -479,9 +479,6 @@ end:
 int ventoy_get_disk_info(ventoy_disk *disk)
 {
     
-    disk->is4kn = ventoy_is_disk_4k_native(disk);
-    if (disk->is4kn < 0) return 1;
-    
     strcpy(disk->disk_path, udisks_block_get_device(disk->blockdev));
     strcpy(disk->disk_name, disk->disk_path);
 
@@ -502,6 +499,10 @@ int ventoy_get_disk_info(ventoy_disk *disk)
     if (bus == NULL) bus = "-";
     
     scnprintf(disk->disk_model, "%s %s (%s)", vendor, model, bus);
+
+    disk->is4kn = ventoy_is_disk_4k_native(disk);
+    if (disk->is4kn < 0) return 1;
+    
 
     ventoy_get_vtoy_data(disk);
     

--- a/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.c
+++ b/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.c
@@ -499,6 +499,7 @@ int ventoy_get_disk_info(ventoy_disk *disk)
     if (bus == NULL) bus = "-";
     
     scnprintf(disk->disk_model, "%s %s (%s)", vendor, model, bus);
+    g_object_unref(drive);
 
     disk->is4kn = ventoy_is_disk_4k_native(disk);
     if (disk->is4kn < 0) return 1;
@@ -578,8 +579,6 @@ int ventoy_disk_enumerate_all(void)
 
         if (udisks_block_get_hint_system(block)) continue;
         
-        if (udisks_block_get_hint_ignore(block)) continue;
-
         if (udisks_object_peek_partition(obj) != NULL) continue;  // It must not be a partition
 
         // The block and the drive are not the same object
@@ -589,6 +588,7 @@ int ventoy_disk_enumerate_all(void)
         disk.obj = obj;
         disk.blockdev = block;
         disk.table = table;
+        disk.hint_ignore = udisks_block_get_hint_ignore(block);
         ventoy_get_disk_info(&disk);//check for error..
 
         g_array_append_val(disks, disk);

--- a/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.c
+++ b/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.c
@@ -369,7 +369,7 @@ int ventoy_get_vtoy_data(ventoy_disk *disk)
     }
     
     /* step 6: save partitions start/end and preserved space */
-    if (strcmp(udisks_partition_table_get_type_(disk->table), "gpt"))
+    if (strcmp(udisks_partition_table_get_type_(disk->table), "gpt") == 0)
     {
         part_style = GPT_PART_STYLE;
 

--- a/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.c
+++ b/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.c
@@ -35,24 +35,109 @@
 #include <ventoy_disk.h>
 #include <ventoy_util.h>
 #include <fat_filelib.h>
+#include <udisks/udisks.h>
 
-int g_disk_num = 0;
 static int g_fatlib_media_fd = 0;
 static uint64_t g_fatlib_media_offset = 0;
-ventoy_disk *g_disk_list = NULL;
 
-static const char *g_ventoy_dev_type_str[VTOY_DEVICE_END] = 
-{
-    "unknown", "scsi", "USB", "ide", "dac960",
-    "cpqarray", "file", "ataraid", "i2o",
-    "ubd", "dasd", "viodasd", "sx8", "dm",
-    "xvd", "sd/mmc", "virtblk", "aoe",
-    "md", "loopback", "nvme", "brd", "pmem"
-};
+// UDisks2 context
+static UDisksClient *client;
+GArray *disks = NULL;
 
-static const char * ventoy_get_dev_type_name(ventoy_dev_type type)
+// static const char *g_ventoy_dev_type_str[VTOY_DEVICE_END] = 
+// {
+//     "unknown", "scsi", "USB", "ide", "dac960",
+//     "cpqarray", "file", "ataraid", "i2o",
+//     "ubd", "dasd", "viodasd", "sx8", "dm",
+//     "xvd", "sd/mmc", "virtblk", "aoe",
+//     "md", "loopback", "nvme", "brd", "pmem"
+// };
+
+/**
+ * Get a ref to the client [transfer: none]
+ */
+UDisksClient *get_udisks_client()
 {
-    return (type < VTOY_DEVICE_END) ? g_ventoy_dev_type_str[type] : "unknown";
+    return client;
+}
+
+/**
+ * Null safe disks length check
+ */
+int get_disks_len()
+{
+    if (disks == NULL) return 0;
+
+    return disks->len;
+}
+
+/**
+ * Do not free the returned pointer
+ */
+ventoy_disk *disks_get_by_name(const char *diskname)
+{
+   
+    for (int i = 0; i < disks->len; i++)
+    {
+        ventoy_disk *current = &g_array_index(disks, ventoy_disk, i);
+
+        if (strcmp(current->disk_name, diskname) == 0)
+        {
+            return current;
+        }
+    }
+
+    return NULL;
+}
+
+int ventoy_disk_open(ventoy_disk *disk, const char *mode, int flags)
+{
+    
+    GVariant *options;
+
+    {
+        GVariantBuilder builder;
+        g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+        g_variant_builder_add(&builder,
+                              "{sv}",
+                              "flags",
+                              g_variant_new_int32(flags));
+        options = g_variant_builder_end(&builder);
+        g_variant_ref_sink(options);
+    }
+
+    GVariant *out_fd = NULL;
+    GUnixFDList *out_fd_list = NULL;
+    
+    GError *error = NULL;
+    udisks_block_call_open_device_sync(disk->blockdev,
+                                       mode,
+                                       options,
+                                       NULL,
+                                       &out_fd,
+                                       &out_fd_list,
+                                       NULL,
+                                       &error);
+
+    g_variant_unref(options);
+    
+    if (error != NULL)
+    {
+        vlog("Failed to open device: %s\n", error->message);
+        g_error_free(error);
+        return -1;
+    }
+
+    gint fd = g_unix_fd_list_get(out_fd_list, g_variant_get_handle(out_fd), &error);
+
+    if (error != NULL)
+    {
+        vlog("Failed to open device: %s\n", error->message);
+        g_error_free(error);
+        return -1;
+    }
+
+    return (int)fd;
 }
 
 static int ventoy_check_blk_major(int major, const char *type)
@@ -100,253 +185,52 @@ static int ventoy_check_blk_major(int major, const char *type)
     return valid;
 }
 
-static int ventoy_get_disk_devnum(const char *name, int *major, int* minor)
+static uint64_t ventoy_get_disk_devnum(const ventoy_disk *disk)
 {
-    int rc;
-    char *pos;
-    char devnum[16] = {0};
-    
-    rc = ventoy_get_sys_file_line(devnum, sizeof(devnum), "/sys/block/%s/dev", name);
-    if (rc)
-    {
-        return 1;
-    }
-
-    pos = strstr(devnum, ":");
-    if (!pos)
-    {
-        return 1;
-    }
-
-    *major = (int)strtol(devnum, NULL, 10);
-    *minor = (int)strtol(pos + 1, NULL, 10);
-
-    return 0;
+    return udisks_block_get_device_number(disk->blockdev);
 }
 
-static ventoy_dev_type ventoy_get_dev_type(const char *name, int major, int minor)
+
+int ventoy_is_disk_4k_native(ventoy_disk *disk)
 {
-    int rc;
-    char syspath[128];
-    char dstpath[256];
-
-    memset(syspath, 0, sizeof(syspath));
-    memset(dstpath, 0, sizeof(dstpath));
-    
-    scnprintf(syspath, "/sys/block/%s", name);
-    rc = readlink(syspath, dstpath, sizeof(dstpath) - 1);
-    if (rc > 0 && strstr(dstpath, "/usb"))
-    {
-        return VTOY_DEVICE_USB;
-    }
-    
-    if (SCSI_BLK_MAJOR(major) && (minor % 0x10 == 0)) 
-    {
-        return VTOY_DEVICE_SCSI;
-    }
-    else if (IDE_BLK_MAJOR(major) && (minor % 0x40 == 0)) 
-    {
-        return VTOY_DEVICE_IDE;
-    }
-    else if (major == DAC960_MAJOR && (minor % 0x8 == 0)) 
-    {
-        return VTOY_DEVICE_DAC960;
-    }
-    else if (major == ATARAID_MAJOR && (minor % 0x10 == 0)) 
-    {
-        return VTOY_DEVICE_ATARAID;
-    }
-    else if (major == AOE_MAJOR && (minor % 0x10 == 0)) 
-    {
-        return VTOY_DEVICE_AOE;
-    }
-    else if (major == DASD_MAJOR && (minor % 0x4 == 0)) 
-    {
-        return VTOY_DEVICE_DASD;
-    }
-    else if (major == VIODASD_MAJOR && (minor % 0x8 == 0)) 
-    {
-        return VTOY_DEVICE_VIODASD;
-    }
-    else if (SX8_BLK_MAJOR(major) && (minor % 0x20 == 0)) 
-    {
-        return VTOY_DEVICE_SX8;
-    }
-    else if (I2O_BLK_MAJOR(major) && (minor % 0x10 == 0)) 
-    {
-        return VTOY_DEVICE_I2O;
-    }
-    else if (CPQARRAY_BLK_MAJOR(major) && (minor % 0x10 == 0)) 
-    {
-        return VTOY_DEVICE_CPQARRAY;
-    }
-    else if (UBD_MAJOR == major && (minor % 0x10 == 0)) 
-    {
-        return VTOY_DEVICE_UBD;
-    }
-    else if (XVD_MAJOR == major && (minor % 0x10 == 0)) 
-    {
-        return VTOY_DEVICE_XVD;
-    }
-    else if (SDMMC_MAJOR == major && (minor % 0x8 == 0)) 
-    {
-        return VTOY_DEVICE_SDMMC;
-    }
-    else if (ventoy_check_blk_major(major, "virtblk"))
-    {
-        return VTOY_DEVICE_VIRTBLK;
-    }
-    else if (major == LOOP_MAJOR)
-    {
-        return VTOY_DEVICE_LOOP;
-    }
-    else if (major == MD_MAJOR)
-    {
-        return VTOY_DEVICE_MD;
-    }
-    else if (major == RAM_MAJOR)
-    {
-        return VTOY_DEVICE_RAM;
-    }
-    else if (strstr(name, "nvme") && ventoy_check_blk_major(major, "blkext"))
-    {
-        return VTOY_DEVICE_NVME;
-    }
-    else if (strstr(name, "pmem") && ventoy_check_blk_major(major, "blkext"))
-    {
-        return VTOY_DEVICE_PMEM;
-    }
-    
-    return VTOY_DEVICE_END;
-}
-
-static int ventoy_is_possible_blkdev(const char *name)
-{
-    if (name[0] == '.')
-    {
-        return 0;
-    }
-
-    /* /dev/ramX */
-    if (name[0] == 'r' && name[1] == 'a' && name[2] == 'm')
-    {
-        return 0;
-    }
-    
-    /* /dev/zramX */
-    if (name[0] == 'z' && name[1] == 'r' && name[2] == 'a' && name[3] == 'm')
-    {
-        return 0;
-    }
-
-    /* /dev/loopX */
-    if (name[0] == 'l' && name[1] == 'o' && name[2] == 'o' && name[3] == 'p')
-    {
-        return 0;
-    }
-
-    /* /dev/dm-X */
-    if (name[0] == 'd' && name[1] == 'm' && name[2] == '-' && isdigit(name[3]))
-    {
-        return 0;
-    }
-
-    /* /dev/srX */
-    if (name[0] == 's' && name[1] == 'r' && isdigit(name[2]))
-    {
-        return 0;
-    }
-    
-    return 1;
-}
-
-int ventoy_is_disk_4k_native(const char *disk)
-{
-    int fd;
     int rc = 0;
     int logsector = 0;
     int physector = 0;
-    char diskpath[256] = {0};
 
-    snprintf(diskpath, sizeof(diskpath) - 1, "/dev/%s", disk);
-
-    fd = open(diskpath, O_RDONLY | O_BINARY);
-    if (fd >= 0)
+    int fd = ventoy_disk_open(disk, "r", O_BINARY);
+    if (fd < 1)
     {
-        ioctl(fd, BLKSSZGET, &logsector);
-        ioctl(fd, BLKPBSZGET, &physector);
-        
-        if (logsector == 4096 && physector == 4096)
-        {
-            rc = 1;
-        }
-        close(fd);
+        vlog("Can't open device %s", disk->disk_model);
+        return -1;
+    };
+
+    ioctl(fd, BLKSSZGET, &logsector);
+    ioctl(fd, BLKPBSZGET, &physector);
+    
+    if (logsector == 4096 && physector == 4096)
+    {
+        rc = 1;
     }
 
     vdebug("is 4k native disk <%s> <%d>\n", disk, rc);    
     return rc;
 }
 
-uint64_t ventoy_get_disk_size_in_byte(const char *disk)
+uint64_t ventoy_get_disk_size_in_byte(const ventoy_disk *disk)
 {
-    int fd;
-    int rc;
-    unsigned long long size = 0;
-    char diskpath[256] = {0};
-    char sizebuf[64] = {0};
-
-    // Try 1: get size from sysfs
-    snprintf(diskpath, sizeof(diskpath) - 1, "/sys/block/%s/size", disk);
-    if (access(diskpath, F_OK) >= 0)
-    {
-        vdebug("get disk size from sysfs for %s\n", disk);
-        
-        fd = open(diskpath, O_RDONLY | O_BINARY);
-        if (fd >= 0)
-        {
-            read(fd, sizebuf, sizeof(sizebuf));
-            size = strtoull(sizebuf, NULL, 10);
-            close(fd);
-            return (uint64_t)(size * 512);
-        }
-    }
-    else
-    {
-        vdebug("%s not exist \n", diskpath);
-    }
-
-    // Try 2: get size from ioctl
-    snprintf(diskpath, sizeof(diskpath) - 1, "/dev/%s", disk);
-    fd = open(diskpath, O_RDONLY);
-    if (fd >= 0)
-    {
-        vdebug("get disk size from ioctl for %s\n", disk);
-        rc = ioctl(fd, BLKGETSIZE64, &size);
-        if (rc == -1)
-        {
-            size = 0;
-            vdebug("failed to ioctl %d\n", rc);
-        }
-        close(fd);
-    }
-    else
-    {
-        vdebug("failed to open %s %d\n", diskpath, errno);
-    }
-
-    vdebug("disk %s size %llu bytes\n", disk, size);
-    return size;
+    return udisks_block_get_size(disk->blockdev);
 }
 
-int ventoy_get_disk_vendor(const char *name, char *vendorbuf, int bufsize)
-{
-    return ventoy_get_sys_file_line(vendorbuf, bufsize, "/sys/block/%s/device/vendor", name);
-}
+// We can get this from the drive
+// int ventoy_get_disk_vendor(const ventoy_disk *disk)
+// {
+//     return udisks_block_get_drive(disk->blockdev)->
+// }
 
-int ventoy_get_disk_model(const char *name, char *modelbuf, int bufsize)
-{
-    return ventoy_get_sys_file_line(modelbuf, bufsize, "/sys/block/%s/device/model", name);
-}
+// int ventoy_get_disk_model(const ventoy_disk *disk)
+// {
+//     return ventoy_get_sys_file_line(modelbuf, bufsize, "/sys/block/%s/device/model", name);
+// }
 
 static int fatlib_media_sector_read(uint32 sector, uint8 *buffer, uint32 sector_count)
 {
@@ -431,10 +315,11 @@ static int fatlib_get_ventoy_version(char *verbuf, int bufsize)
     return rc;
 }
 
-int ventoy_get_vtoy_data(ventoy_disk *info, int *ppartstyle)
+int ventoy_get_vtoy_data(ventoy_disk *disk)
 {
+    if (disk->table == NULL) return 1;
+
     int i;
-    int fd;
     int len;
     int rc = 1;
     int ret = 1;
@@ -448,46 +333,47 @@ int ventoy_get_vtoy_data(ventoy_disk *info, int *ppartstyle)
     disk_ventoy_data *vtoy = NULL;    
     VTOY_GPT_INFO *gpt = NULL;
     
-    vtoy = &(info->vtoydata);
+    vtoy = &(disk->vtoydata);
     gpt = &(vtoy->gptinfo);
+
+    /* step 1: Init memory */
     memset(vtoy, 0, sizeof(disk_ventoy_data));
 
-    vdebug("ventoy_get_vtoy_data %s\n", info->disk_path);
+    vdebug("ventoy_get_vtoy_data %s\n", udisks_block_get_device(disk->blockdev));
 
-    if (info->size_in_byte < (2 * VTOYEFI_PART_BYTES))
+    /* step 2: Check size */
+    if (udisks_block_get_size(disk->blockdev) < (2 * VTOYEFI_PART_BYTES))
     {
-        vdebug("disk %s is too small %llu\n", info->disk_path, (_ull)info->size_in_byte);
+        vdebug("disk %s is too small %llu\n", udisks_block_get_device(disk->blockdev), (_ull)udisks_block_get_size(disk->blockdev));
         return 1;
     }
 
-    fd = open(info->disk_path, O_RDONLY | O_BINARY);
-    if (fd < 0)
-    {
-        vdebug("failed to open %s %d\n", info->disk_path, errno);
-        return 1;
-    }
+    /* step 3: open the device */
+    int fd = ventoy_disk_open(disk, "r", O_BINARY);
 
-    len = (int)read(fd, &(vtoy->gptinfo), sizeof(VTOY_GPT_INFO));
+    if (fd < 1) return 1;
+
+    /* step 4: read gpt table */
+    len = (int)read(fd, gpt, sizeof(VTOY_GPT_INFO));
     if (len != sizeof(VTOY_GPT_INFO))
     {
-        vdebug("failed to read %s %d\n", info->disk_path, errno);
+        vdebug("failed to read %s %d\n", udisks_block_get_device(disk->blockdev), errno);
         goto end;
     }
 
+    /* step 5: handle invalid magic */
     if (gpt->MBR.Byte55 != 0x55 || gpt->MBR.ByteAA != 0xAA)
     {
         vdebug("Invalid mbr magic 0x%x 0x%x\n", gpt->MBR.Byte55, gpt->MBR.ByteAA);
         goto end;
     }
-
-    if (gpt->MBR.PartTbl[0].FsFlag == 0xEE && strncmp(gpt->Head.Signature, "EFI PART", 8) == 0)
+    
+    /* step 6: save partitions start/end and preserved space */
+    if (strcmp(udisks_partition_table_get_type_(disk->table), "gpt"))
     {
         part_style = GPT_PART_STYLE;
-        if (ppartstyle)
-        {
-            *ppartstyle = part_style;
-        }
 
+        /* checks that 2 partitions are present */
         if (gpt->PartTbl[0].StartLBA == 0 || gpt->PartTbl[1].StartLBA == 0)
         {
             vdebug("NO ventoy efi part layout <%llu %llu>\n", 
@@ -496,6 +382,7 @@ int ventoy_get_vtoy_data(ventoy_disk *info, int *ppartstyle)
             goto end;
         }
 
+        /* the second one must be naed VTOYEFI for ventoy to be installed */
         for (i = 0; i < 36; i++)
         {
             name[i] = (char)(gpt->PartTbl[1].Name[i]);
@@ -511,24 +398,21 @@ int ventoy_get_vtoy_data(ventoy_disk *info, int *ppartstyle)
         part2_start_sector = gpt->PartTbl[1].StartLBA;
         part2_sector_count = gpt->PartTbl[1].LastLBA - part2_start_sector + 1;
 
-        preserved_space = info->size_in_byte - (part2_start_sector + part2_sector_count + 33) * 512;
+        preserved_space = udisks_block_get_size(disk->blockdev) - (part2_start_sector + part2_sector_count + 33) * 512;
     }
     else
     {
         part_style = MBR_PART_STYLE;
-        if (ppartstyle)
-        {
-            *ppartstyle = part_style;
-        }
-        
+
         part1_start_sector = gpt->MBR.PartTbl[0].StartSectorId;
         part1_sector_count = gpt->MBR.PartTbl[0].SectorCount;
         part2_start_sector = gpt->MBR.PartTbl[1].StartSectorId;
         part2_sector_count = gpt->MBR.PartTbl[1].SectorCount;
 
-        preserved_space = info->size_in_byte - (part2_start_sector + part2_sector_count) * 512;
+        preserved_space = udisks_block_get_size(disk->blockdev) - (part2_start_sector + part2_sector_count) * 512;
     }
 
+    /* step 7: check for ventoy partition layout */
     if (part1_start_sector != VTOYIMG_PART_START_SECTOR ||
         part2_sector_count != VTOYEFI_PART_SECTORS ||
         (part1_start_sector + part1_sector_count) != part2_start_sector)
@@ -543,7 +427,8 @@ int ventoy_get_vtoy_data(ventoy_disk *info, int *ppartstyle)
 
     vtoy->ventoy_valid = 1;
 
-    vdebug("now check secure boot for %s ...\n", info->disk_path);
+    /* step 8: check for secure boot */
+    vdebug("now check secure boot for %s ...\n", udisks_block_get_device(disk->blockdev));
 
     g_fatlib_media_fd = fd;
     g_fatlib_media_offset = part2_start_sector;
@@ -587,169 +472,154 @@ int ventoy_get_vtoy_data(ventoy_disk *info, int *ppartstyle)
     vtoy->partition_style = part_style;
     vtoy->part2_start_sector = part2_start_sector;
 
-    rc = 0;
 end:
-    vtoy_safe_close_fd(fd);
-    return rc;
+    return 0;
 }
 
-int ventoy_get_disk_info(const char *name, ventoy_disk *info)
+int ventoy_get_disk_info(ventoy_disk *disk)
 {
-    char vendor[64] = {0};
-    char model[128] = {0};
+    
+    disk->is4kn = ventoy_is_disk_4k_native(disk);
+    if (disk->is4kn < 0) return 1;
+    
+    strcpy(disk->disk_path, udisks_block_get_device(disk->blockdev));
+    strcpy(disk->disk_name, disk->disk_path);
 
-    vdebug("get disk info %s\n", name);
+    // ventoy_get_disk_devnum(name, &disk->major, &disk->minor);
+    // ventoy_get_disk_vendor(name, vendor, sizeof(vendor));
+    // ventoy_get_disk_model(name, model, sizeof(model));
 
-    strlcpy(info->disk_name, name);
-    scnprintf(info->disk_path, "/dev/%s", name);
+    scnprintf(disk->human_readable_size, "%llu GB", (_ull)ventoy_get_human_readable_gb(udisks_block_get_size(disk->blockdev)));
+    UDisksDrive *drive = udisks_client_get_drive_for_block(client, disk->blockdev);
 
-    if (strstr(name, "nvme") || strstr(name, "mmc") || strstr(name, "nbd"))
+    char *vendor = udisks_drive_get_vendor(drive);
+    if (vendor == NULL) vendor = "-";
+    
+    char *model = udisks_drive_get_model(drive);
+    if (vendor == NULL) vendor = "-";
+
+    char *bus = udisks_drive_get_connection_bus(drive);
+    if (bus == NULL) bus = "-";
+    
+    scnprintf(disk->disk_model, "%s %s (%s)", vendor, model, bus);
+
+    ventoy_get_vtoy_data(disk);
+    
+    // vdebug("disk:<%s %d:%d> model:<%s> size:%llu (%s)\n", 
+    //     disk->disk_path, disk->major, disk->minor, disk->disk_model, udisks_block_get_size(disk->blockdev), disk->human_readable_size);
+
+    if (disk->vtoydata.ventoy_valid)
     {
-        scnprintf(info->part1_name, "%sp1", name);
-        scnprintf(info->part1_path, "/dev/%sp1", name);
-        scnprintf(info->part2_name, "%sp2", name);
-        scnprintf(info->part2_path, "/dev/%sp2", name);
+        vdebug("%s Ventoy:<%s> %s secureboot:%d preserve:%llu\n", udisks_block_get_device(disk->blockdev), disk->vtoydata.ventoy_ver, 
+            disk->vtoydata.partition_style == MBR_PART_STYLE ? "MBR" : "GPT",
+            disk->vtoydata.secure_boot_flag, (_ull)(disk->vtoydata.preserved_space));
     }
     else
     {
-        scnprintf(info->part1_name, "%s1", name);
-        scnprintf(info->part1_path, "/dev/%s1", name);
-        scnprintf(info->part2_name, "%s2", name);
-        scnprintf(info->part2_path, "/dev/%s2", name);
-    }
-    
-    info->is4kn = ventoy_is_disk_4k_native(name);
-    info->size_in_byte = ventoy_get_disk_size_in_byte(name);
-
-    ventoy_get_disk_devnum(name, &info->major, &info->minor);
-    info->type = ventoy_get_dev_type(name, info->major, info->minor);
-    ventoy_get_disk_vendor(name, vendor, sizeof(vendor));
-    ventoy_get_disk_model(name, model, sizeof(model));
-
-    scnprintf(info->human_readable_size, "%llu GB", (_ull)ventoy_get_human_readable_gb(info->size_in_byte));
-    scnprintf(info->disk_model, "%s %s (%s)", vendor, model, ventoy_get_dev_type_name(info->type));
-
-    ventoy_get_vtoy_data(info, &(info->partstyle));
-    
-    vdebug("disk:<%s %d:%d> model:<%s> size:%llu (%s)\n", 
-        info->disk_path, info->major, info->minor, info->disk_model, info->size_in_byte, info->human_readable_size);
-
-    if (info->vtoydata.ventoy_valid)
-    {
-        vdebug("%s Ventoy:<%s> %s secureboot:%d preserve:%llu\n", info->disk_path, info->vtoydata.ventoy_ver, 
-            info->vtoydata.partition_style == MBR_PART_STYLE ? "MBR" : "GPT",
-            info->vtoydata.secure_boot_flag, (_ull)(info->vtoydata.preserved_space));
-    }
-    else
-    {
-        vdebug("%s NO Ventoy detected\n", info->disk_path);
+        vdebug("%s NO Ventoy detected\n", udisks_block_get_device(disk->blockdev));
     }
 
     return 0;
 }
 
-static int ventoy_disk_compare(const ventoy_disk *disk1, const ventoy_disk *disk2)
-{
-    if (disk1->type == VTOY_DEVICE_USB && disk2->type == VTOY_DEVICE_USB)
-    {
-        return strcmp(disk1->disk_name, disk2->disk_name);
-    }
-    else if (disk1->type == VTOY_DEVICE_USB)
-    {
-        return -1;
-    }
-    else if (disk2->type == VTOY_DEVICE_USB)
-    {
-        return 1;
-    }
-    else
-    {
-        return strcmp(disk1->disk_name, disk2->disk_name);
-    }
-}
+// static int ventoy_disk_compare(const ventoy_disk *disk1, const ventoy_disk *disk2)
+// {
+//     if (disk1->type == VTOY_DEVICE_USB && disk2->type == VTOY_DEVICE_USB)
+//     {
+//         return strcmp(disk1->disk_name, disk2->disk_name);
+//     }
+//     else if (disk1->type == VTOY_DEVICE_USB)
+//     {
+//         return -1;
+//     }
+//     else if (disk2->type == VTOY_DEVICE_USB)
+//     {
+//         return 1;
+//     }
+//     else
+//     {
+//         return strcmp(disk1->disk_name, disk2->disk_name);
+//     }
+// }
 
-static int ventoy_disk_sort(void)
-{
-    int i, j;
-    ventoy_disk *tmp;
-
-    tmp = malloc(sizeof(ventoy_disk));
-    if (!tmp)
-    {
-        return 1;
-    }
-
-    for (i = 0; i < g_disk_num; i++)
-    for (j = i + 1; j < g_disk_num; j++)
-    {
-        if (ventoy_disk_compare(g_disk_list + i, g_disk_list + j) > 0)
-        {
-            memcpy(tmp, g_disk_list + i, sizeof(ventoy_disk));
-            memcpy(g_disk_list + i, g_disk_list + j, sizeof(ventoy_disk));
-            memcpy(g_disk_list + j, tmp, sizeof(ventoy_disk));
-        }
-    }
-
-    free(tmp);
-    return 0;
-}
 
 int ventoy_disk_enumerate_all(void)
 {
-    int rc = 0;
-    DIR* dir = NULL;
-    struct dirent* p = NULL;
-
     vdebug("ventoy_disk_enumerate_all\n");
 
-    dir = opendir("/sys/block");
-    if (!dir)
+    if (disks != NULL)
     {
-        vlog("Failed to open /sys/block %d\n", errno);
-        return 1;
-    }
-
-    while (((p = readdir(dir)) != NULL) && (g_disk_num < MAX_DISK_NUM))
-    {
-        if (ventoy_is_possible_blkdev(p->d_name))
+        for (int i = 0; i < disks->len; ++i)
         {
-            memset(g_disk_list + g_disk_num, 0, sizeof(ventoy_disk));
-            if (0 == ventoy_get_disk_info(p->d_name, g_disk_list + g_disk_num))
-            {
-                g_disk_num++;                    
-            }
-        }
-    }
-    closedir(dir);
+            ventoy_disk *disk = &g_array_index(disks, ventoy_disk, i);
 
-    ventoy_disk_sort();
-    
-    return rc;
+            if (disk->obj) g_object_unref(disk->obj);
+            if (disk->blockdev) g_object_unref(disk->blockdev);
+            if (disk->table) g_object_unref(disk->table);
+        }
+
+        g_array_free(disks, TRUE);
+    }
+
+    disks = g_array_new(FALSE, FALSE, sizeof(ventoy_disk));
+
+    GList *el = g_dbus_object_manager_get_objects(udisks_client_get_object_manager(client));
+
+    for (; el != NULL; el = el->next)
+    {
+        UDisksObject *obj = UDISKS_OBJECT (el->data);
+        UDisksBlock *block = udisks_object_get_block(obj);
+        UDisksPartitionTable *table = udisks_object_get_partition_table(obj);
+
+        if (block == NULL) continue;
+
+        if (udisks_block_get_device(block) == NULL) continue;
+
+        if (udisks_block_get_hint_system(block)) continue;
+        
+        if (udisks_block_get_hint_ignore(block)) continue;
+
+        if (udisks_object_peek_partition(obj) != NULL) continue;  // It must not be a partition
+
+        // The block and the drive are not the same object
+        if (udisks_block_get_drive(block) == NULL || strcmp(udisks_block_get_drive(block), "/") == 0) continue;
+
+        ventoy_disk disk;
+        disk.obj = obj;
+        disk.blockdev = block;
+        disk.table = table;
+        ventoy_get_disk_info(&disk);//check for error..
+
+        g_array_append_val(disks, disk);
+    }
+
+    // Here we could sort the array...
+
+    return 0;
 }
 
 void ventoy_disk_dump(ventoy_disk *cur)
 {
     if (cur->vtoydata.ventoy_valid)
     {
-        vdebug("%s [%s] %s\tVentoy: %s %s secureboot:%d preserve:%llu\n", 
-            cur->disk_path, cur->human_readable_size, cur->disk_model,
+        vdebug("%s [%s]\tVentoy: %s %s secureboot:%d preserve:%llu\n", 
+            udisks_block_get_device(cur->blockdev), cur->human_readable_size,
             cur->vtoydata.ventoy_ver, cur->vtoydata.partition_style == MBR_PART_STYLE ? "MBR" : "GPT",
             cur->vtoydata.secure_boot_flag, (_ull)(cur->vtoydata.preserved_space));
     }
     else
     {
-        vdebug("%s [%s] %s\tVentoy: NA\n", cur->disk_path, cur->human_readable_size, cur->disk_model); 
+        vdebug("%s [%s]\tVentoy: NA\n", udisks_block_get_device(cur->blockdev), cur->human_readable_size); 
     }
 }
 
 void ventoy_disk_dump_all(void)
 {
-    int i;
-    
     vdebug("============= DISK DUMP ============\n");
-    for (i = 0; i < g_disk_num; i++)
+    for (int i = 0; i < disks->len; i++)
     {
-        ventoy_disk_dump(g_disk_list + i);
+        ventoy_disk *disk = &g_array_index(disks, ventoy_disk, i);
+        ventoy_disk_dump(disk);
     }
 }
 
@@ -761,7 +631,16 @@ int ventoy_disk_install(ventoy_disk *disk, void *efipartimg)
 
 int ventoy_disk_init(void)
 {
-    g_disk_list = malloc(sizeof(ventoy_disk) * MAX_DISK_NUM);
+    GError *error = NULL;
+    client = udisks_client_new_sync(NULL, &error);
+    disks = NULL;
+
+    if (!client)
+    {
+        vlog("Error connecting to UDisks: %s\n", error->message);
+        g_error_free(error);
+        return 1;
+    }
 
     ventoy_disk_enumerate_all();
     ventoy_disk_dump_all();
@@ -771,9 +650,14 @@ int ventoy_disk_init(void)
 
 void ventoy_disk_exit(void)
 {
-    check_free(g_disk_list);        
-    g_disk_list = NULL;
-    g_disk_num  = 0;
+    for (int i = 0; i < disks->len; ++i)
+    {
+        ventoy_disk disk = g_array_index(disks, ventoy_disk, i);
+
+        g_object_unref(disk.blockdev);
+        g_object_unref(disk.table);
+    }
+    g_array_free(disks, TRUE);
+    disks = NULL;
+    g_object_unref(client);
 }
-
-

--- a/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.h
+++ b/LinuxGUI/Ventoy2Disk/Core/ventoy_disk.h
@@ -20,126 +20,138 @@
 #ifndef __VENTOY_DISK_H__
 #define __VENTOY_DISK_H__
 
-typedef enum 
-{
-    VTOY_DEVICE_UNKNOWN = 0,
-    VTOY_DEVICE_SCSI,
-    VTOY_DEVICE_USB,
-    VTOY_DEVICE_IDE,
-    VTOY_DEVICE_DAC960,
-    VTOY_DEVICE_CPQARRAY,
-    VTOY_DEVICE_FILE,
-    VTOY_DEVICE_ATARAID,
-    VTOY_DEVICE_I2O,
-    VTOY_DEVICE_UBD,
-    VTOY_DEVICE_DASD,
-    VTOY_DEVICE_VIODASD,
-    VTOY_DEVICE_SX8,
-    VTOY_DEVICE_DM,
-    VTOY_DEVICE_XVD,
-    VTOY_DEVICE_SDMMC,
-    VTOY_DEVICE_VIRTBLK,
-    VTOY_DEVICE_AOE,
-    VTOY_DEVICE_MD,
-    VTOY_DEVICE_LOOP,
-    VTOY_DEVICE_NVME,
-    VTOY_DEVICE_RAM,
-    VTOY_DEVICE_PMEM,
+// typedef enum 
+// {
+//     VTOY_DEVICE_UNKNOWN = 0,
+//     VTOY_DEVICE_SCSI,
+//     VTOY_DEVICE_USB,
+//     VTOY_DEVICE_IDE,
+//     VTOY_DEVICE_DAC960,
+//     VTOY_DEVICE_CPQARRAY,
+//     VTOY_DEVICE_FILE,
+//     VTOY_DEVICE_ATARAID,
+//     VTOY_DEVICE_I2O,
+//     VTOY_DEVICE_UBD,
+//     VTOY_DEVICE_DASD,
+//     VTOY_DEVICE_VIODASD,
+//     VTOY_DEVICE_SX8,
+//     VTOY_DEVICE_DM,
+//     VTOY_DEVICE_XVD,
+//     VTOY_DEVICE_SDMMC,
+//     VTOY_DEVICE_VIRTBLK,
+//     VTOY_DEVICE_AOE,
+//     VTOY_DEVICE_MD,
+//     VTOY_DEVICE_LOOP,
+//     VTOY_DEVICE_NVME,
+//     VTOY_DEVICE_RAM,
+//     VTOY_DEVICE_PMEM,
     
-    VTOY_DEVICE_END
-}ventoy_dev_type;
+//     VTOY_DEVICE_END
+// }ventoy_dev_type;
 
-/* from <linux/major.h> */
-#define IDE0_MAJOR              3
-#define IDE1_MAJOR              22
-#define IDE2_MAJOR              33
-#define IDE3_MAJOR              34
-#define IDE4_MAJOR              56
-#define IDE5_MAJOR              57
-#define SCSI_CDROM_MAJOR        11
-#define SCSI_DISK0_MAJOR        8
-#define SCSI_DISK1_MAJOR        65
-#define SCSI_DISK2_MAJOR        66
-#define SCSI_DISK3_MAJOR        67
-#define SCSI_DISK4_MAJOR        68
-#define SCSI_DISK5_MAJOR        69
-#define SCSI_DISK6_MAJOR        70
-#define SCSI_DISK7_MAJOR        71
-#define SCSI_DISK8_MAJOR        128
-#define SCSI_DISK9_MAJOR        129
-#define SCSI_DISK10_MAJOR       130
-#define SCSI_DISK11_MAJOR       131
-#define SCSI_DISK12_MAJOR       132
-#define SCSI_DISK13_MAJOR       133
-#define SCSI_DISK14_MAJOR       134
-#define SCSI_DISK15_MAJOR       135
-#define COMPAQ_SMART2_MAJOR     72
-#define COMPAQ_SMART2_MAJOR1    73
-#define COMPAQ_SMART2_MAJOR2    74
-#define COMPAQ_SMART2_MAJOR3    75
-#define COMPAQ_SMART2_MAJOR4    76
-#define COMPAQ_SMART2_MAJOR5    77
-#define COMPAQ_SMART2_MAJOR6    78
-#define COMPAQ_SMART2_MAJOR7    79
-#define COMPAQ_SMART_MAJOR      104
-#define COMPAQ_SMART_MAJOR1     105
-#define COMPAQ_SMART_MAJOR2     106
-#define COMPAQ_SMART_MAJOR3     107
-#define COMPAQ_SMART_MAJOR4     108
-#define COMPAQ_SMART_MAJOR5     109
-#define COMPAQ_SMART_MAJOR6     110
-#define COMPAQ_SMART_MAJOR7     111
-#define DAC960_MAJOR            48
-#define ATARAID_MAJOR           114
-#define I2O_MAJOR1              80
-#define I2O_MAJOR2              81
-#define I2O_MAJOR3              82
-#define I2O_MAJOR4              83
-#define I2O_MAJOR5              84
-#define I2O_MAJOR6              85
-#define I2O_MAJOR7              86
-#define I2O_MAJOR8              87
-#define UBD_MAJOR               98
-#define DASD_MAJOR              94
-#define VIODASD_MAJOR           112
-#define AOE_MAJOR               152
-#define SX8_MAJOR1              160
-#define SX8_MAJOR2              161
-#define XVD_MAJOR               202
-#define SDMMC_MAJOR             179
-#define LOOP_MAJOR              7
-#define MD_MAJOR                9
-#define BLKEXT_MAJOR            259
-#define RAM_MAJOR               1
+// /* from <linux/major.h> */
+// #define IDE0_MAJOR              3
+// #define IDE1_MAJOR              22
+// #define IDE2_MAJOR              33
+// #define IDE3_MAJOR              34
+// #define IDE4_MAJOR              56
+// #define IDE5_MAJOR              57
+// #define SCSI_CDROM_MAJOR        11
+// #define SCSI_DISK0_MAJOR        8
+// #define SCSI_DISK1_MAJOR        65
+// #define SCSI_DISK2_MAJOR        66
+// #define SCSI_DISK3_MAJOR        67
+// #define SCSI_DISK4_MAJOR        68
+// #define SCSI_DISK5_MAJOR        69
+// #define SCSI_DISK6_MAJOR        70
+// #define SCSI_DISK7_MAJOR        71
+// #define SCSI_DISK8_MAJOR        128
+// #define SCSI_DISK9_MAJOR        129
+// #define SCSI_DISK10_MAJOR       130
+// #define SCSI_DISK11_MAJOR       131
+// #define SCSI_DISK12_MAJOR       132
+// #define SCSI_DISK13_MAJOR       133
+// #define SCSI_DISK14_MAJOR       134
+// #define SCSI_DISK15_MAJOR       135
+// #define COMPAQ_SMART2_MAJOR     72
+// #define COMPAQ_SMART2_MAJOR1    73
+// #define COMPAQ_SMART2_MAJOR2    74
+// #define COMPAQ_SMART2_MAJOR3    75
+// #define COMPAQ_SMART2_MAJOR4    76
+// #define COMPAQ_SMART2_MAJOR5    77
+// #define COMPAQ_SMART2_MAJOR6    78
+// #define COMPAQ_SMART2_MAJOR7    79
+// #define COMPAQ_SMART_MAJOR      104
+// #define COMPAQ_SMART_MAJOR1     105
+// #define COMPAQ_SMART_MAJOR2     106
+// #define COMPAQ_SMART_MAJOR3     107
+// #define COMPAQ_SMART_MAJOR4     108
+// #define COMPAQ_SMART_MAJOR5     109
+// #define COMPAQ_SMART_MAJOR6     110
+// #define COMPAQ_SMART_MAJOR7     111
+// #define DAC960_MAJOR            48
+// #define ATARAID_MAJOR           114
+// #define I2O_MAJOR1              80
+// #define I2O_MAJOR2              81
+// #define I2O_MAJOR3              82
+// #define I2O_MAJOR4              83
+// #define I2O_MAJOR5              84
+// #define I2O_MAJOR6              85
+// #define I2O_MAJOR7              86
+// #define I2O_MAJOR8              87
+// #define UBD_MAJOR               98
+// #define DASD_MAJOR              94
+// #define VIODASD_MAJOR           112
+// #define AOE_MAJOR               152
+// #define SX8_MAJOR1              160
+// #define SX8_MAJOR2              161
+// #define XVD_MAJOR               202
+// #define SDMMC_MAJOR             179
+// #define LOOP_MAJOR              7
+// #define MD_MAJOR                9
+// #define BLKEXT_MAJOR            259
+// #define RAM_MAJOR               1
 
-#define SCSI_BLK_MAJOR(M) (                                             \
-                (M) == SCSI_DISK0_MAJOR                                 \
-                || (M) == SCSI_CDROM_MAJOR                              \
-                || ((M) >= SCSI_DISK1_MAJOR && (M) <= SCSI_DISK7_MAJOR) \
-                || ((M) >= SCSI_DISK8_MAJOR && (M) <= SCSI_DISK15_MAJOR))
+// #define SCSI_BLK_MAJOR(M) (                                             \
+//                 (M) == SCSI_DISK0_MAJOR                                 \
+//                 || (M) == SCSI_CDROM_MAJOR                              \
+//                 || ((M) >= SCSI_DISK1_MAJOR && (M) <= SCSI_DISK7_MAJOR) \
+//                 || ((M) >= SCSI_DISK8_MAJOR && (M) <= SCSI_DISK15_MAJOR))
 
-#define IDE_BLK_MAJOR(M) \
-    ((M) == IDE0_MAJOR || \
-    (M) == IDE1_MAJOR || \
-    (M) == IDE2_MAJOR || \
-    (M) == IDE3_MAJOR || \
-    (M) == IDE4_MAJOR || \
-    (M) == IDE5_MAJOR)
+// #define IDE_BLK_MAJOR(M) \
+//     ((M) == IDE0_MAJOR || \
+//     (M) == IDE1_MAJOR || \
+//     (M) == IDE2_MAJOR || \
+//     (M) == IDE3_MAJOR || \
+//     (M) == IDE4_MAJOR || \
+//     (M) == IDE5_MAJOR)
 
-#define SX8_BLK_MAJOR(M) ((M) >= SX8_MAJOR1 && (M) <= SX8_MAJOR2)
-#define I2O_BLK_MAJOR(M) ((M) >= I2O_MAJOR1 && (M) <= I2O_MAJOR8)
-#define CPQARRAY_BLK_MAJOR(M)  \
-    (((M) >= COMPAQ_SMART2_MAJOR && (M) <= COMPAQ_SMART2_MAJOR7) || \
-    (COMPAQ_SMART_MAJOR <= (M) && (M) <= COMPAQ_SMART_MAJOR7))
+// #define SX8_BLK_MAJOR(M) ((M) >= SX8_MAJOR1 && (M) <= SX8_MAJOR2)
+// #define I2O_BLK_MAJOR(M) ((M) >= I2O_MAJOR1 && (M) <= I2O_MAJOR8)
+// #define CPQARRAY_BLK_MAJOR(M)  \
+//     (((M) >= COMPAQ_SMART2_MAJOR && (M) <= COMPAQ_SMART2_MAJOR7) || \
+//     (COMPAQ_SMART_MAJOR <= (M) && (M) <= COMPAQ_SMART_MAJOR7))
+//
+
+#include <udisks/udisks.h>
+#include <ventoy_define.h>
 
 #define VENTOY_FILE_STG1_IMG    "boot/core.img.xz"
 #define VENTOY_FILE_DISK_IMG    "ventoy/ventoy.disk.img.xz"
 
-extern int g_disk_num;
-extern ventoy_disk *g_disk_list;
+/**
+ * Global disks array
+ * NOTE: Do not access len directly since it is not null-safe. Use get_disks_len() instead.
+ */
+extern GArray *disks;
+
+UDisksClient *get_udisks_client();
 int ventoy_disk_enumerate_all(void);
 int ventoy_disk_init(void);
 void ventoy_disk_exit(void);
+int ventoy_disk_open(ventoy_disk *disk, const char *mode, int flags);
+ventoy_disk *disks_get_by_name(const char *diskname);
+int get_disks_len();
 
 #endif /* __VENTOY_DISK_H__ */
 

--- a/LinuxGUI/Ventoy2Disk/Core/ventoy_util.h
+++ b/LinuxGUI/Ventoy2Disk/Core/ventoy_util.h
@@ -40,7 +40,7 @@ int ventoy_get_sys_file_line(char *buffer, int buflen, const char *fmt, ...);
 uint64_t ventoy_get_human_readable_gb(uint64_t SizeBytes);
 void ventoy_md5(const void *data, uint32_t len, uint8_t *md5);
 int ventoy_is_disk_mounted(const char *devpath);
-int ventoy_try_umount_disk(const char *devpath);
+int ventoy_try_umount_disk(const ventoy_disk *disk);
 int unxz(unsigned char *in, int in_size,
 	 int (*fill)(void *dest, unsigned int size),
 	 int (*flush)(void *src, unsigned int size),

--- a/LinuxGUI/Ventoy2Disk/GTK/ventoy_gtk.c
+++ b/LinuxGUI/Ventoy2Disk/GTK/ventoy_gtk.c
@@ -231,13 +231,13 @@ void on_devlist_changed(GtkWidget *widget, gpointer data)
     gtk_label_set_text(g_label_dev_part_style, "");
 
     active = gtk_combo_box_get_active((GtkComboBox *)g_dev_combobox);
-    if (active < 0 || active >= g_disk_num)
+    if (active < 0 || active >= get_disks_len())
     {
         vlog("invalid active combox id %d\n", active);
         return;
     }
 
-    cur = g_disk_list + active;
+    cur = &g_array_index(disks, ventoy_disk, active);
     if (cur->vtoydata.ventoy_valid)
     {
         if (cur->vtoydata.secure_boot_flag)
@@ -308,14 +308,12 @@ static ventoy_disk *select_active_dev(const char *select, int *activeid)
     /* find the match one */
     if (select)
     {
-        for (i = 0; i < g_disk_num; i++)
+        for (i = 0; i < get_disks_len(); i++)
         {
-            cur = g_disk_list + i;
-            if (alldev == 0 && cur->type != VTOY_DEVICE_USB)
-            {
-                continue;
-            }
-            
+            cur = &g_array_index(disks, ventoy_disk, i);
+
+            if (!alldev && cur->hint_ignore) continue;
+                        
             if (strcmp(cur->disk_name, select) == 0)
             {
                 *activeid = i;
@@ -325,13 +323,11 @@ static ventoy_disk *select_active_dev(const char *select, int *activeid)
     }
 
     /* find the first one that installed with Ventoy */
-    for (i = 0; i < g_disk_num; i++)
+    for (i = 0; i < get_disks_len(); i++)
     {
-        cur = g_disk_list + i;
-        if (alldev == 0 && cur->type != VTOY_DEVICE_USB)
-        {
-            continue;
-        }
+        cur = &g_array_index(disks, ventoy_disk, i);
+
+        if (!alldev && cur->hint_ignore) continue;
         
         if (cur->vtoydata.ventoy_valid)
         {
@@ -341,29 +337,30 @@ static ventoy_disk *select_active_dev(const char *select, int *activeid)
     }
 
     /* find the first USB interface device */
-    for (i = 0; i < g_disk_num; i++)
+    for (i = 0; i < get_disks_len(); i++)
     {
-        cur = g_disk_list + i;
-        if (alldev == 0 && cur->type != VTOY_DEVICE_USB)
-        {
-            continue;
-        }
+        cur = &g_array_index(disks, ventoy_disk, i);
+
+        if (!alldev && cur->hint_ignore) continue;
         
-        if (cur->type == VTOY_DEVICE_USB)
+        UDisksDrive *drive = udisks_client_get_drive_for_block(get_udisks_client(), cur->blockdev);
+        char *bus = udisks_drive_get_connection_bus(drive);
+
+        if (strcmp(bus, "usb") == 0)
         {
             *activeid = i;
+            g_object_unref(drive);
             return cur;
         }
+        g_object_unref(drive);
     }
 
     /* use the first one */
-    for (i = 0; i < g_disk_num; i++)
+    for (i = 0; i < get_disks_len(); i++)
     {
-        cur = g_disk_list + i;
-        if (alldev == 0 && cur->type != VTOY_DEVICE_USB)
-        {
-            continue;
-        }
+        cur = &g_array_index(disks, ventoy_disk, i);
+
+        if (!alldev && cur->hint_ignore) continue;
         
         *activeid = i;
         return cur;
@@ -387,20 +384,17 @@ static void fill_dev_list(const char *select)
 
     alldev = ventoy_code_get_cur_show_all();
     
-    vlog("fill_dev_list total disk: %d showall:%d\n", g_disk_num, alldev);
+    vlog("fill_dev_list total disk: %d showall:%d\n", get_disks_len(), alldev);
 
     /* gtk_combo_box_text_remove_all */
     store = GTK_LIST_STORE(gtk_combo_box_get_model(GTK_COMBO_BOX(g_dev_combobox)));
     gtk_list_store_clear(store);
 
-    for (i = 0; i < g_disk_num; i++)
+    for (i = 0; i < get_disks_len(); i++)
     {
-        cur = g_disk_list + i;
+        cur = &g_array_index(disks, ventoy_disk, i);
 
-        if (alldev == 0 && cur->type != VTOY_DEVICE_USB)
-        {
-            continue;
-        }
+        if (!alldev && cur->hint_ignore) continue;
 
         g_snprintf(line, sizeof(line), "%s  [%s]  %s", cur->disk_name, cur->human_readable_size, cur->disk_model);
         gtk_combo_box_text_append_text(g_dev_combobox, line);
@@ -489,7 +483,7 @@ void on_clear_ventoy(GtkMenuItem *menuItem, gpointer data)
     }
 
     active = gtk_combo_box_get_active((GtkComboBox *)g_dev_combobox);
-    if (active < 0 || active >= g_disk_num)
+    if (active < 0 || active >= get_disks_len())
     {
         vlog("invalid active combox id %d\n", active);
         return;
@@ -511,7 +505,7 @@ void on_clear_ventoy(GtkMenuItem *menuItem, gpointer data)
     g_thread_run = TRUE;
 
 
-    cur = g_disk_list + active;
+    cur = &g_array_index(disks, ventoy_disk, active);
     g_snprintf(disk_name, sizeof(disk_name), "%s", cur->disk_name);
     g_snprintf(buf, sizeof(buf), "{\"method\":\"clean\",\"disk\":\"%s\"}", disk_name);
 
@@ -653,13 +647,13 @@ void on_button_install_clicked(GtkWidget *widget, gpointer data)
     }
 
     active = gtk_combo_box_get_active((GtkComboBox *)g_dev_combobox);
-    if (active < 0 || active >= g_disk_num)
+    if (active < 0 || active >= get_disks_len())
     {
         vlog("invalid active combox id %d\n", active);
         return;
     }
 
-    cur = g_disk_list + active;
+    cur = &g_array_index(disks, ventoy_disk, active);
 
     if (cur->is4kn)
     {
@@ -667,7 +661,7 @@ void on_button_install_clicked(GtkWidget *widget, gpointer data)
         return;
     }
 
-    if (ventoy_code_get_cur_part_style() == 0 && cur->size_in_byte > 2199023255552ULL)
+    if (ventoy_code_get_cur_part_style() == MBR_PART_STYLE && udisks_block_get_size(cur->blockdev) > 0x20000000000ULL)
     {
         msgbox(GTK_MESSAGE_ERROR, GTK_BUTTONS_OK, "STR_DISK_2TB_MBR_ERROR");
         return;
@@ -685,7 +679,7 @@ void on_button_install_clicked(GtkWidget *widget, gpointer data)
             space = space;
         }
 
-        size = cur->size_in_byte / SIZE_1MB;
+        size = udisks_block_get_size(cur->blockdev)/ SIZE_1MB;
         if (size <= space || (size - space) <= (VTOYEFI_PART_BYTES / SIZE_1MB))
     	{
     	    msgbox(GTK_MESSAGE_ERROR, GTK_BUTTONS_OK, "STR_SPACE_VAL_INVALID");
@@ -782,12 +776,12 @@ void on_button_update_clicked(GtkWidget *widget, gpointer data)
     }
 
     active = gtk_combo_box_get_active((GtkComboBox *)g_dev_combobox);
-    if (active < 0 || active >= g_disk_num)
+    if (active < 0 || active >= get_disks_len())
     {
         vlog("invalid active combox id %d\n", active);
         return;
     }
-    cur = g_disk_list + active;    
+    cur = &g_array_index(disks, ventoy_disk, active);
 
     if (cur->vtoydata.ventoy_valid == 0)
     {

--- a/LinuxGUI/Ventoy2Disk/Web/ventoy_http.c
+++ b/LinuxGUI/Ventoy2Disk/Web/ventoy_http.c
@@ -1317,6 +1317,8 @@ static int ventoy_api_get_dev_list(struct mg_connection *conn, VTOY_JSON *json)
     for (i = 0; i < get_disks_len(); i++)
     {
         cur = &g_array_index(disks, ventoy_disk, i);
+
+        if (!alldev && cur->hint_ignore) continue;
       
         VTOY_JSON_FMT_OBJ_BEGIN();
         VTOY_JSON_FMT_STRN("name", cur->disk_name);

--- a/LinuxGUI/Ventoy2Disk/Web/ventoy_http.c
+++ b/LinuxGUI/Ventoy2Disk/Web/ventoy_http.c
@@ -1106,9 +1106,9 @@ static int ventoy_api_install(struct mg_connection *conn, VTOY_JSON *json)
         return 0;
     }
 
-    int size_in_bytes =  udisks_block_get_size(disk->blockdev);
+    guint64 size_in_bytes =  udisks_block_get_size(disk->blockdev);
     
-    if (size_in_bytes > 2199023255552ULL && style == 0)
+    if (size_in_bytes > 0x20000000000ULL && style == 0)
     {
         vlog("disk %s is more than 2TB and GPT is needed\n", path);
         ventoy_json_result(conn, VTOY_JSON_MBR_2TB_RET);

--- a/LinuxGUI/Ventoy2Disk/main_gtk.c
+++ b/LinuxGUI/Ventoy2Disk/main_gtk.c
@@ -113,13 +113,6 @@ int main(int argc, char *argv[])
 
     gtk_init(&argc, &argv);
     
-    if (geteuid() != 0)
-    {
-        early_msgbox(GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, 
-                     "Ventoy2Disk permission denied!\r\nPlease run with root privileges.");
-        return EACCES;
-    }
-
     if (access("./boot/boot.img", F_OK) == -1)
     {
         adjust_cur_dir(argv[0]);        

--- a/LinuxGUI/assets/org.ventoy.VentoyGUI.desktop
+++ b/LinuxGUI/assets/org.ventoy.VentoyGUI.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Ventoy GUI
 GenericName=USB Flasher
-Comment=Multi-ISO USB flashing utility, using GRUB
+Comment=Multi-ISO bootable-USB creator
 Icon=org.ventoy.VentoyGUI
 Categories=System
 Keywords="USB;Flash;Drive;Ventoy"

--- a/LinuxGUI/assets/org.ventoy.VentoyGUI.desktop
+++ b/LinuxGUI/assets/org.ventoy.VentoyGUI.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Ventoy GUI
+GenericName=USB Flasher
+Comment=Multi-ISO USB flashing utility, using GRUB
+Icon=org.ventoy.VentoyGUI
+Categories=System
+Keywords="USB;Flash;Drive;Ventoy"
+Terminal=false
+Exec=ventoy-gtk3.sh

--- a/LinuxGUI/assets/org.ventoy.VentoyGUI.metainfo.xml
+++ b/LinuxGUI/assets/org.ventoy.VentoyGUI.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.ventoy.VentoyGUI</id>
+  
+  <name>Ventoy GUI</name>
+  <summary>Multi-ISO bootable-USB creator</summary>
+  
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  
+  <description>
+    <p>
+      Ventoy is an open source tool to create bootable USB drive for ISO/WIM/IMG/VHD(x)/EFI files. With ventoy, you don&apos;t need to format the disk over and over, you just need to copy the ISO/WIM/IMG/VHD(x)/EFI files to the USB drive and boot them directly. You can copy many files at a time and ventoy will give you a boot menu to select them. You can also browse ISO/WIM/IMG/VHD(x)/EFI files in local disks and boot them. x86 Legacy BIOS, IA32 UEFI, x86_64 UEFI, ARM64 UEFI and MIPS64EL UEFI are supported in the same way. Most types of OS supported (Windows/WinPE/Linux/ChromeOS/Unix/VMware/Xen...)
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">org.ventoy.VentoyGUI.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://ventoy.net/static/img/screen/screen_bios2.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://www.ventoy.net/</url>
+</component>

--- a/LinuxGUI/build.sh
+++ b/LinuxGUI/build.sh
@@ -30,6 +30,7 @@ build_func() {
         -I ./Ventoy2Disk/Lib/exfat/src/libexfat \
         -I ./Ventoy2Disk/Lib/exfat/src/mkfs \
         -I ./Ventoy2Disk/Lib/fat_io_lib \
+        $(pkg-config --libs -cflags udisks2) \
         \
         -L ./Ventoy2Disk/Lib/fat_io_lib/lib \
         Ventoy2Disk/main_webui.c \

--- a/LinuxGUI/build_gtk.sh
+++ b/LinuxGUI/build_gtk.sh
@@ -5,6 +5,8 @@ build_func() {
     toolDir=$3
     gtkver=$4   
 
+    UDISKS2=$(pkg-config --libs -cflags udisks2)
+
     if [ "$libsuffix" = "aa64" ]; then
         EXD=./EXLIB/aarch64
         GTKFLAG="-pthread -I$EXD/usr/include/gtk-3.0 -I$EXD/usr/include/atk-1.0 -I$EXD/usr/include/at-spi2-atk/2.0 -I$EXD/usr/include/pango-1.0 -I$EXD/usr/include/gio-unix-2.0/ -I$EXD/usr/include/cairo -I$EXD/usr/include/gdk-pixbuf-2.0 -I$EXD/usr/include/glib-2.0 -I$EXD/usr/lib64/glib-2.0/include -I$EXD/usr/include/at-spi-2.0 -I$EXD/usr/include/dbus-1.0 -I$EXD/usr/lib64/dbus-1.0/include -I$EXD/usr/include/harfbuzz -I$EXD/usr/include/freetype2 -I$EXD/usr/include/pixman-1 -I$EXD/usr/include/libpng15 -I$EXD/usr/include/libdrm"
@@ -64,6 +66,7 @@ build_func() {
         Ventoy2Disk/Lib/exfat/src/mkfs/*.c \
         Ventoy2Disk/Lib/fat_io_lib/*.c \
         $XXLIB \
+        $UDISKS2 \
         -l pthread \
         ./civetweb.o \
         -o Ventoy2Disk.${gtkver}_$libsuffix $XXFLAG 
@@ -81,15 +84,13 @@ build_func() {
     rm -f ../INSTALL/tool/$toolDir/Ventoy2Disk.${gtkver}_$libsuffix
     cp -a Ventoy2Disk.${gtkver}_$libsuffix ../INSTALL/tool/$toolDir/Ventoy2Disk.${gtkver}
     
-    $1 -O2 -D_FILE_OFFSET_BITS=64 Ventoy2Disk/ventoy_gui.c Ventoy2Disk/Core/ventoy_json.c -I Ventoy2Disk/Core  -DVTOY_GUI_ARCH="\"$toolDir\"" -o VentoyGUI.$toolDir
+    $1 $UDISKS2 -O2 -D_FILE_OFFSET_BITS=64 Ventoy2Disk/ventoy_gui.c Ventoy2Disk/Core/ventoy_json.c -I Ventoy2Disk/Core  -DVTOY_GUI_ARCH="\"$toolDir\"" -o VentoyGUI.$toolDir
     cp -a VentoyGUI.$toolDir ../INSTALL/
 }
 
 
 build_func "gcc" '64' 'x86_64' 'gtk3'
-
 build_func "gcc" '64' 'x86_64' 'gtk2'
-
 build_func "gcc -m32" '32' 'i386' 'gtk2'
 build_func "gcc -m32" '32' 'i386' 'gtk3'
 

--- a/LinuxGUI/build_gtk.sh
+++ b/LinuxGUI/build_gtk.sh
@@ -88,14 +88,25 @@ build_func() {
     cp -a VentoyGUI.$toolDir ../INSTALL/
 }
 
+print_help() {
+    echo "Usage: ./build_gtk.sh <ARCH> <gtk2|gtk3>"
+}
 
-build_func "gcc" '64' 'x86_64' 'gtk3'
-build_func "gcc" '64' 'x86_64' 'gtk2'
-build_func "gcc -m32" '32' 'i386' 'gtk2'
-build_func "gcc -m32" '32' 'i386' 'gtk3'
+if [[ $# -ne 2 ]] || [[ $2 -ne 'gtk2' && $2 -ne 'gtk3' ]]; then
+    print_help
+    exit 1
+fi
 
-build_func "aarch64-linux-gnu-gcc" 'aa64' 'aarch64' 'gtk3'
-
-export PATH=/opt/mips-loongson-gcc8-linux-gnu-2021-02-08/bin/:$PATH
-build_func "mips-linux-gnu-gcc -mips64r2 -mabi=64" 'm64e' 'mips64el' 'gtk3'
-
+case $1 in
+"x86_64")
+    build_func "gcc" '64' 'x86_64' $2 ;;
+"i386")
+    build_func "gcc -m32" '32' 'i386' $2 ;;
+"aarch64")
+     build_func "aarch64-linux-gnu-gcc" 'aa64' 'aarch64' $2 ;;
+"mips64el")
+    export PATH=/opt/mips-loongson-gcc8-linux-gnu-2021-02-08/bin/:$PATH
+    build_func "mips-linux-gnu-gcc -mips64r2 -mabi=64" 'm64e' 'mips64el' $2 ;;
+*)
+    echo "Error: unknown ARCH";;
+esac

--- a/LinuxGUI/org.ventoy.VentoyGUI.yml
+++ b/LinuxGUI/org.ventoy.VentoyGUI.yml
@@ -2,7 +2,7 @@ id: org.ventoy.VentoyGUI
 runtime: org.gnome.Platform
 runtime-version: '48'
 sdk: org.gnome.Sdk
-command: run.sh
+command: ventoy-gtk3.sh
 modules:
   - name: udisks2
     sources:
@@ -176,11 +176,13 @@ modules:
   - name: ventoy_gui
     buildsystem: simple
     sources:
+      # - type: dir
+      #   path: "../../"
       - type: git
         url: https://github.com/LorenzoIanotto/VentoyUDisks.git
         branch: udisks
       - type: script
-        dest-filename: run.sh
+        dest-filename: ventoy-gtk3.sh
         commands:
           - cd /app
           - VentoyGUI --xdg
@@ -188,7 +190,16 @@ modules:
       - cd LinuxGUI && chmod +x ./build_gtk.sh
       - cd LinuxGUI && ./build_gtk.sh $(uname -m) gtk3
       - install -Dm755 LinuxGUI/Ventoy2Disk.gtk3_64 /app/bin/VentoyGUI
-      - install -Dm755 run.sh /app/bin/run.sh
+      - install -Dm755 ventoy-gtk3.sh /app/bin/ventoy-gtk3.sh
+      - install -Dm644 ICON/logo_16.png /app/share/icons/hicolor/16x16/apps/org.ventoy.VentoyGUI.png
+      - install -Dm644 ICON/logo_32.png /app/share/icons/hicolor/32x32/apps/org.ventoy.VentoyGUI.png
+      - install -Dm644 ICON/logo_48.png /app/share/icons/hicolor/48x48/apps/org.ventoy.VentoyGUI.png
+      - install -Dm644 ICON/logo_64.png /app/share/icons/hicolor/64x64/apps/org.ventoy.VentoyGUI.png
+      - install -Dm644 ICON/logo_72.png /app/share/icons/hicolor/72x72/apps/org.ventoy.VentoyGUI.png
+      - install -Dm644 ICON/logo_128.png /app/share/icons/hicolor/128x128/apps/org.ventoy.VentoyGUI.png
+      - install -Dm644 ICON/logo_256.png /app/share/icons/hicolor/256x256/apps/org.ventoy.VentoyGUI.png
+      - install -Dm644 ICON/logo_512.png /app/share/icons/hicolor/512x512/apps/org.ventoy.VentoyGUI.png
+      - install -Dm644 LinuxGUI/assets/org.ventoy.VentoyGUI.desktop /app/share/applications/org.ventoy.VentoyGUI.desktop
 finish-args:
   # X11 + XShm access
   - --share=ipc

--- a/LinuxGUI/org.ventoy.VentoyGUI.yml
+++ b/LinuxGUI/org.ventoy.VentoyGUI.yml
@@ -204,6 +204,4 @@ finish-args:
   # X11 + XShm access
   - --share=ipc
   - --socket=x11
-  # Needs to talk to the network:
-  - --share=network
   - --system-talk-name=org.freedesktop.UDisks2

--- a/LinuxGUI/org.ventoy.VentoyGUI.yml
+++ b/LinuxGUI/org.ventoy.VentoyGUI.yml
@@ -1,0 +1,198 @@
+id: org.ventoy.VentoyGUI
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: run.sh
+modules:
+  - name: udisks2
+    sources:
+      - type: git
+        url: https://github.com/storaged-project/udisks.git
+        branch: 2.10.x-branch
+    config-opts:
+      - "--enable-available-modules=no"
+      - "--enable-bcache=no"
+      - "--enable-btrfs=no"
+      - "--enable-introspection=no"
+      - "--enable-lvm2=no"
+      - "--enable-modules=no"
+      - "--enable-vdo=no"
+      - "--enable-zram=no"
+      - "--disable-smart"
+      - "--with-systemdsystemunitdir=no"
+      - "--with-tmpfilesdir=no"
+    modules:
+      - name: polkit
+        buildsystem: meson
+        sources:
+          - type: git
+            url: https://github.com/polkit-org/polkit.git
+            tag: "126"
+        config-opts:
+          - -Dlibs-only=true
+          - -Dintrospection=false
+        modules:
+          - name: pam
+            sources:
+              - type: archive
+                url: https://github.com/linux-pam/linux-pam/releases/download/v1.4.0/Linux-PAM-1.4.0.tar.xz
+                sha256: cd6d928c51e64139be3bdb38692c68183a509b83d4f2c221024ccd4bcddfd034
+            config-opts:
+              - "--includedir=/app/include/security"
+              - "--disable-doc"
+      - name: libnvme
+        buildsystem: meson
+        sources:
+          - type: git
+            url: https://github.com/linux-nvme/libnvme.git
+      - name: libblockdev
+        sources:
+          - type: git
+            url: https://github.com/storaged-project/libblockdev.git
+            branch: 3.3.x-devel
+        config-opts:
+          - "--disable-tests"
+          - "--with-btrfs=no"
+          - "--with-dm=no"
+          - "--with-gtk-doc=no"
+          - "--with-lvm=no"
+          - "--with-lvm_dbus=no"
+          - "--with-mpath=no"
+          - "--with-nvdimm=no"
+          - "--with-escrow=no"
+          - "--with-tools=no"
+          - "--with-smart=no"
+          - "--with-smartmontools=no"
+        modules:
+          - name: libparted
+            cleanup:
+              - /bin
+              - /share
+            sources:
+              - type: archive
+                url: https://alpha.gnu.org/gnu/parted/parted-3.2.153.tar.xz
+                sha256: a1445d837ac4bc809ff9146ab3ac112ecc1b5639d23b7ea7b668d45aca058a2a
+            config-opts:
+              - --disable-device-mapper
+          - name: kmod
+            buildsystem: meson
+            sources:
+              - type: git
+                url: https://github.com/kmod-project/kmod.git
+                tag: v34
+            config-opts:
+              - -Dbashcompletiondir=no
+              - -Dzshcompletiondir=no
+              - -Dfishcompletiondir=no
+              - -Dtools=false
+              - -Dmanpages=false
+          - name: libaio
+            buildsystem: simple
+            sources:
+              - type: git
+                url: https://github.com/JingchengLi/libaio.git
+            build-commands:
+              - make prefix=/app install
+          - name: lvm2
+            buildsystem: simple
+            sources:
+              - type: git
+                url: https://gitlab.com/lvmteam/lvm2.git
+                tag: v2_03_34
+            make-args:
+              - device-mapper
+            build-options:
+              no-debuginfo: true
+            build-commands:
+              - ./configure --prefix=/app --exec-prefix=/app --enable-pkgconfig
+              - make install_device-mapper
+              - cd libdm && make install_pkgconfig
+              - chmod 755 /app/lib/libdevmapper.so
+              - chmod 755 /app/sbin/dmsetup
+          - name: libcryptsetup
+            sources:
+              - type: git
+                url: https://gitlab.com/cryptsetup/cryptsetup.git
+                branch: v2.7.x
+            config-opts:
+              - --disable-asciidoc
+              - --disable-ssh-token
+            modules:
+              - name: libpopt
+                buildsystem: cmake
+                sources:
+                  - type: git
+                    url: https://github.com/rpm-software-management/popt.git
+              - name: json-c
+                buildsystem: cmake
+                sources:
+                  - type: git
+                    url: https://github.com/json-c/json-c.git
+                    tag: json-c-0.18-20240915
+          - name: keyutils
+            buildsystem: simple
+            sources:
+              - type: archive
+                url: https://src.fedoraproject.org/repo/pkgs/keyutils/keyutils-1.6.1.tar.bz2/sha512/ea6e20b2594234c7f51581eef2b8fd19c109fa9eacaaef8dfbb4f237bd1d6fdf071ec23b4ff334cb22a46461d09d17cf499987fd1f00e66f27506888876961e1/keyutils-1.6.1.tar.bz2
+                sha256: c8b15722ae51d95b9ad76cc6d49a4c2cc19b0c60f72f61fb9bf43eea7cbd64ce
+            build-commands:
+              - make
+              - make LIBDIR=/app/lib BINDIR=/app/bin SBINDIR=/app/sbin INCLUDEDIR=/app/include MANDIR=/app/share/man SHAREDIR=/app/share/keyutils install
+          - name: bytesize
+            sources:
+              - type: git
+                url: https://github.com/storaged-project/libbytesize.git
+                tag: "2.11"
+          - name: fdisk
+            buildsystem: meson
+            config-opts:
+              - "-Dauto_features=disabled"
+              - "-Dbuild-libfdisk=enabled"
+              - "-Dbuild-fdisks=enabled"
+              - "-Dbuild-libuuid=enabled"
+              - "-Dbuild-libblkid=enabled"
+              - "-Duse-tty-group=false"
+              - "-Dlibutil=enabled"
+            sources:
+              - type: git
+                url: https://github.com/util-linux/util-linux.git
+      - name: atasmart
+        buildsystem: autotools
+        sources:
+          - type: git
+            url: https://github.com/libatasmart/libatasmart.git
+            tag: v0.19
+  - name: ventoy_release
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://github.com/ventoy/Ventoy/releases/download/v1.1.05/ventoy-1.1.05-linux.tar.gz
+        sha256: 3379c99890359dcff55aab7f7b3286f87c988d1da2fd616e6a9e305fb0a1de9e
+        strip-components: 1
+    build-commands:
+      # - chmod +x "ventoy-1.1.05/VentoyGUI.$(uname -m)"
+      # - mv "ventoy-1.1.05/VentoyGUI.$(uname -m)" ventoy-1.1.05/VentoyGUI
+      - cp -r ventoy-1.1.05/* /app/
+  - name: ventoy_gui
+    buildsystem: simple
+    sources:
+      - type: git
+        url: https://github.com/LorenzoIanotto/VentoyUDisks.git
+        branch: udisks
+      - type: script
+        dest-filename: run.sh
+        commands:
+          - cd /app
+          - VentoyGUI --xdg
+    build-commands:
+      - cd LinuxGUI && chmod +x ./build_gtk.sh
+      - cd LinuxGUI && ./build_gtk.sh $(uname -m) gtk3
+      - install -Dm755 LinuxGUI/Ventoy2Disk.gtk3_64 /app/bin/VentoyGUI
+      - install -Dm755 run.sh /app/bin/run.sh
+finish-args:
+  # X11 + XShm access
+  - --share=ipc
+  - --socket=x11
+  # Needs to talk to the network:
+  - --share=network
+  - --system-talk-name=org.freedesktop.UDisks2

--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
-# LinuxGUI UDisks2 + Flatpak
-This is a fork of Ventoy which uses UDisks2 as a backend for LinuxGUI, so it can run as a flatpak.
-
-## Development
-
-You can get started with
-
-```
-flatpak-builder --force-clean --user --install-deps-from=flathub --repo=repo --install output LinuxGUI/org.ventoy.VentoyGUI.yml
-```
-
-(See https://docs.flatpak.org/en/latest/first-build.html)
-
 <h1 align="center">
   <a href=https://www.ventoy.net/>Ventoy</a>
 </h1>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# LinuxGUI UDisks2 + Flatpak
+This is a fork of Ventoy which uses UDisks2 as a backend for LinuxGUI, so it can run as a flatpak.
+
+## Development
+
+You can get started with
+
+```
+flatpak-builder --force-clean --user --install-deps-from=flathub --repo=repo --install output LinuxGUI/org.ventoy.VentoyGUI.yml
+```
+
+(See https://docs.flatpak.org/en/latest/first-build.html)
+
 <h1 align="center">
   <a href=https://www.ventoy.net/>Ventoy</a>
 </h1>


### PR DESCRIPTION
Hi,
I have managed to port LinuxGUI to Flatpak using UDisks2 as a backend. UDisks2 is mandatory since accessing drives directly needs root privileges, which we do not have in a sandbox.
It currently works on x86_64 (see LinuxGUI/README.md).
Currently the app id is `org.ventoy.VentoyGUI`, maybe we should change it to `net.ventoy.VentoyGUI` since we control the ventoy.net domain?

Thanks