### PR TITLE
Fix small grammar issue in GRUB's hardware info page

### DIFF
--- a/INSTALL/grub/hwinfo.cfg
+++ b/INSTALL/grub/hwinfo.cfg
@@ -40,17 +40,17 @@ menuentry "$VTLANG_HWINFO" --class=debug_hwinfo --class=F5tool {
     echo "Physical RAM            $grub_total_ram MB"
                                   
     echo ""                       
-    echo "Manufacture             $system_vendor"
+    echo "Manufacturer            $system_vendor"
     echo "Product Name            $system_product"
     echo "Version                 $system_version"
                                   
     echo ""                       
-    echo "Board Manufacture       $board_vendor"
+    echo "Board Manufacturer      $board_vendor"
     echo "Board Name              $board_product"
     echo "Board Version           $board_version"
                                   
     echo ""                       
-    echo "BIOS Manufacture        $bios_vendor"
+    echo "BIOS Manufacturer       $bios_vendor"
     echo "BIOS Version            $bios_ver"
     echo "BIOS Date               $bios_date"
     echo "BIOS ROM Size           $bios_size"


### PR DESCRIPTION
Hi there,

Sorry for the small PR! A letter `r` was missing from the end of the word, it's Manufacture**r**, not ~Manufacture~, it was bothering me a bit so I submitted this PR.

Thanks for the awesome project! 👍🏻 