### PR TITLE
Support booting T2SDE ISOs better

### DIFF
--- a/IMG/cpio/ventoy/hook/t2/disk_hook.sh
+++ b/IMG/cpio/ventoy/hook/t2/disk_hook.sh
@@ -25,7 +25,19 @@ fi
 
 VTPATH_OLD=$PATH; PATH=$BUSYBOX_PATH:$VTOY_PATH/tool:$PATH
 
-modprobe dm-mod
+vtlog "Loading dax and dm-mod module ..."
+$BUSYBOX_PATH/modprobe dax      > /dev/null 2>&1
+$BUSYBOX_PATH/modprobe dm-mod   > /dev/null 2>&1
+
+if $GREP -q 'device-mapper' /proc/devices; then
+    vtlog "dm-mod module check success ..."
+else
+    vtlog "Need to extract dax and dm-mod module ..."
+    $VTOY_PATH/tool/zstdcat /lib/modules/$(uname -r)/drivers/dax/dax.ko.zst > $VTOY_PATH/extract_dax.ko
+    $BUSYBOX_PATH/insmod $VTOY_PATH/extract_dax.ko
+    $VTOY_PATH/tool/zstdcat /lib/modules/$(uname -r)/drivers/md/dm-mod.ko.zst > $VTOY_PATH/extract_dm_mod.ko
+    $BUSYBOX_PATH/insmod $VTOY_PATH/extract_dm_mod.ko
+fi
 
 wait_for_usb_disk_ready
 


### PR DESCRIPTION
Add fallback to uncompress `dax.ko.zst` and `dm-mod.ko.zst` and insmod this in the t2 disk_hook.sh, as the default busybox modprobe/insmod doesn't support zstd modules.

[T2 Linux](https://t2linux.com/) uses zstd compressed kernel modules, where `dm-mod` also depends on the `dax` module, since recent kernel versions.  So the [default fallback](https://github.com/ventoy/Ventoy/blob/master/IMG/cpio/ventoy/hook/ventoy-hook-lib.sh#L215) to only decompress `dm-mod` isn't sufficient.

To boot this ISO e.g: [t2-25.1-x86-64-base-wayland-glibc-gcc-nocona.iso](https://dl.t2sde.org/binary/2025/t2-25.1-x86-64-base-wayland-glibc-gcc-nocona.iso)