### PR TITLE
Fix secure boot flag description in README

### DIFF
--- a/INSTALL/README
+++ b/INSTALL/README
@@ -11,7 +11,7 @@ Ventoy2Disk.sh CMD [ OPTION ] /dev/sdX
     
   OPTION: (optional)
    -r SIZE_MB  preserve some space at the bottom of the disk (only for install)
-   -s          enable secure boot support (default is disabled)
+   -S          disable secure boot support (default is enabled)
    -g          use GPT partition style, default is MBR style (only for install)
 
 Please refer https://www.ventoy.net/en/doc_start.html for details.   


### PR DESCRIPTION
Secure boot is enabled by default since 1.0.76 per documentation. VentoyWorker.sh was updated accordingly already. The README still states it was disabled by default. Updated to "default is enabled" and -S for disabling instead of -s for enabling secure boot.