### PR TITLE
Improve booting of T2SDE live ISOs

### DIFF
--- a/IMG/cpio/ventoy/hook/t2/ventoy-hook.sh
+++ b/IMG/cpio/ventoy/hook/t2/ventoy-hook.sh
@@ -19,6 +19,8 @@
 
 . $VTOY_PATH/hook/ventoy-os-lib.sh
 
+$SED  "/Searching/i $BUSYBOX_PATH/sh $VTOY_PATH/hook/t2/disk_hook.sh"  -i /init
+$SED  "/disktype/i x=/dev/ventoy"  -i /init
 $SED  "/getdevice *devicefile/i $BUSYBOX_PATH/sh $VTOY_PATH/hook/t2/disk_hook.sh"  -i /init
 $SED  "/getdevice *devicefile/a devicefile=/dev/ventoy"  -i /init
 

--- a/IMG/cpio/ventoy/ventoy_chain.sh
+++ b/IMG/cpio/ventoy/ventoy_chain.sh
@@ -314,8 +314,8 @@ ventoy_get_os_type() {
     fi
     
     
-    if [ -e /init ]; then
-        if $GREP -q -m1 'T2 SDE' /init; then
+    if [ -e /etc/initrd-release ]; then
+        if $GREP -q -m1 't2sde' /etc/initrd-release; then
             echo 't2'; return
         fi
     fi

--- a/IMG/cpio/ventoy/ventoy_loop.sh
+++ b/IMG/cpio/ventoy/ventoy_loop.sh
@@ -344,8 +344,8 @@ ventoy_get_os_type() {
     fi
     
     
-    if [ -e /init ]; then
-        if $GREP -q -m1 'T2 SDE' /init; then
+    if [ -e /etc/initrd-release ]; then
+        if $GREP -q -m1 't2sde' /etc/initrd-release; then
             echo 't2'; return
         fi
     fi


### PR DESCRIPTION
T2SDE changed the boot process vastly with new release [26.3 Desktop Edition](https://t2linux.com/download/26.3) as it ships as a live image now. So the injection hooks need to be customized. The disk_hook.sh is noted twice to keep compatibility with the older ISO releases.

As tested with the image:
https://dl.t2sde.org/binary/2026/t2-26.3-x86-64-desktop.iso