### PR TITLE
Add filename to the "File checksum" label in the secondary menu

### DIFF
--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/ventoy/ventoy_cmd.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/ventoy/ventoy_cmd.c
@@ -6286,7 +6286,7 @@ static grub_err_t ventoy_cmd_show_secondary_menu(grub_extcmd_context_t ctxt, int
         }
     }
 
-    vtoy_dummy_menuentry(cmd, pos, len, "$VTLANG_FILE_CHKSUM", "second_checksum"); seldata[n++] = 5;
+    vtoy_dummy_menuentry(cmd, pos, len, "$VTLANG_FILE_CHKSUM for \\\"$vt_chosen_name\\\"", "second_checksum"); seldata[n++] = 5;
     vtoy_dummy_menuentry(cmd, pos, len, "$VTLANG_RETURN_PRV_NOESC", "second_return"); seldata[n++] = 6;
 
     do {


### PR DESCRIPTION
Hello!

| Screenshot | Screen Recording |
|:-:|:-:|
| <img width="1167" height="1318" alt="image" src="https://github.com/user-attachments/assets/83d87c62-6cb3-44a0-bd0f-928f03cf97de" /> | If you are in hurry, <video src="https://github.com/user-attachments/assets/e77b853a-ec8b-4602-820a-52baf2d06d9d"> |

```diff
  Boot in normal mode
  Boot in grub2 mode
  Boot in memdisk mode
- File checksum
+ File checksum for "..."
  Return to previous menu

```

This may help fat fingers as users will have the opportunity to check which file they selected.