### PR TITLE
fix: pin 1 unpinned action

### DIFF
--- a/.github/workflows/sync2gitee.yml
+++ b/.github/workflows/sync2gitee.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Mirror the Github repos to Gitee.
-      uses: Yikun/hub-mirror-action@master
+      uses: Yikun/hub-mirror-action@09420c987e7b1670577495eed7d8c8062e938050 # master
       with:
         src: github/ventoy
         dst: gitee/LongPanda


### PR DESCRIPTION
Re-submission of #3544. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins a GitHub Action to an immutable commit SHA instead of a mutable branch reference.

- Pin `Yikun/hub-mirror-action@master` to full 40-character SHA

## How to verify

Review the diff, the change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@master` becomes `action@abc123 # master`, original ref preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)