### PR TITLE
Feature: Optional per-class backgrounds for custom themes

### DIFF
--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/gfxmenu.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/gfxmenu.c
@@ -116,6 +116,8 @@ grub_gfxmenu_try (int entry, grub_menu_t menu, int nested)
 			  & GRUB_VIDEO_MODE_TYPE_DOUBLE_BUFFERED)
     && !(mode_info.mode_type & GRUB_VIDEO_MODE_TYPE_UPDATING_SWAP);
   view->selected = entry;
+  if (view->menu != menu)
+    view->class_bg_synced_entry = -1;
   view->menu = menu;
   view->nested = nested;
   view->first_timeout = -1;

--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/view.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/view.c
@@ -49,8 +49,8 @@ static grub_gfxmenu_view_t term_view;
 
 static int
 backgrounds_dir_probe_hook (const char *filename __attribute__((unused)),
-			    const struct grub_dirhook_info *info __attribute__((unused)),
-			    void *data __attribute__((unused)))
+          const struct grub_dirhook_info *info __attribute__((unused)),
+          void *data __attribute__((unused)))
 {
   return 0;
 }
@@ -95,7 +95,7 @@ theme_has_backgrounds_dir (const char *theme_path)
       grub_errno = GRUB_ERR_NONE;
       (fs->fs_dir) (dev, path, backgrounds_dir_probe_hook, NULL);
       if (grub_errno == GRUB_ERR_NONE)
-	ok = 1;
+        ok = 1;
     }
 
 out:
@@ -119,7 +119,7 @@ clone_video_bitmap (struct grub_video_bitmap *src)
     return 0;
 
   if (grub_video_bitmap_create (&dst, src->mode_info.width, src->mode_info.height,
-				src->mode_info.blit_format))
+      src->mode_info.blit_format))
     return 0;
   src_data = grub_video_bitmap_get_data (src);
   dst_data = grub_video_bitmap_get_data (dst);
@@ -132,6 +132,8 @@ clone_video_bitmap (struct grub_video_bitmap *src)
 static void
 setup_class_backgrounds (grub_gfxmenu_view_t view)
 {
+  grub_free (view->class_bg_applied_path);
+  view->class_bg_applied_path = 0;
   view->class_bg_active = 0;
   view->default_desktop_raw = 0;
   view->using_class_bg = 0;
@@ -144,36 +146,23 @@ setup_class_backgrounds (grub_gfxmenu_view_t view)
     {
       view->default_desktop_raw = clone_video_bitmap (view->raw_desktop_image);
       if (!view->default_desktop_raw)
-	return;
+        return;
     }
 
   view->class_bg_active = 1;
 }
 
-static struct grub_video_bitmap *
-try_loading_background_for_class (grub_gfxmenu_view_t view,
-				  const char *class_name)
+static char *
+class_background_png_path (const char *bgs_dir, const char *class_name)
 {
-  struct grub_video_bitmap *raw = 0;
-  char *theme_dir = 0, *bgs_dir = 0, *path = 0, *p = 0;
+  char *path;
+  char *p;
   static const char ext[] = ".png";
 
-  if (!view || !view->theme_path || !class_name)
-    return 0;
-
-  theme_dir = grub_get_dirname (view->theme_path);
-  if (!theme_dir)
-    return 0;
-
-  bgs_dir = grub_resolve_relative_path (theme_dir, "backgrounds/");
-  grub_free (theme_dir);
-  if (!bgs_dir)
-    return 0;
-
   path = grub_malloc (grub_strlen (bgs_dir) + grub_strlen (class_name)
-		      + grub_strlen (ext) + 3);
+          + grub_strlen (ext) + 3);
   if (!path)
-    goto out;
+    return 0;
 
   p = grub_stpcpy (path, bgs_dir);
   if (path == p || p[-1] != '/')
@@ -181,14 +170,7 @@ try_loading_background_for_class (grub_gfxmenu_view_t view,
   p = grub_stpcpy (p, class_name);
   p = grub_stpcpy (p, ext);
   *p = '\0';
-
-  grub_video_bitmap_load (&raw, path);
-  grub_errno = GRUB_ERR_NONE;
-
-out:
-  grub_free (path);
-  grub_free (bgs_dir);
-  return raw;
+  return path;
 }
 
 static void
@@ -201,6 +183,8 @@ restore_default_desktop (grub_gfxmenu_view_t view)
   view->raw_desktop_image = 0;
   view->scaled_desktop_image = 0;
   view->using_class_bg = 0;
+  grub_free (view->class_bg_applied_path);
+  view->class_bg_applied_path = 0;
 
   if (!view->default_desktop_raw)
     return;
@@ -212,28 +196,65 @@ restore_default_desktop (grub_gfxmenu_view_t view)
   init_background (view);
 }
 
-/* Returns 1 if a class background was applied.  */
+
+/* 0 = no class image, 1 = loaded new, 2 = already showing same file.  */
 static int
 maybe_apply_class_background (grub_gfxmenu_view_t view)
 {
   grub_menu_entry_t entry;
   struct grub_menu_entry_class *c;
-  struct grub_video_bitmap *raw;
+  struct grub_video_bitmap *raw = 0;
+  char *theme_dir = 0;
+  char *bgs_dir = 0;
+  char *path = 0;
 
-  if (!view || !view->menu)
+  if (!view || !view->menu || !view->theme_path)
     return 0;
 
   entry = grub_menu_get_entry (view->menu, view->selected);
   if (!entry)
     return 0;
 
+  theme_dir = grub_get_dirname (view->theme_path);
+  if (!theme_dir)
+    return 0;
+  bgs_dir = grub_resolve_relative_path (theme_dir, "backgrounds/");
+  grub_free (theme_dir);
+  if (!bgs_dir)
+    return 0;
+
   for (c = entry->classes; c; c = c->next)
     {
       if (!c->name)
-	continue;
-      raw = try_loading_background_for_class (view, c->name);
+        continue;
+
+      path = class_background_png_path (bgs_dir, c->name);
+      if (!path)
+        {
+          grub_free (bgs_dir);
+          return 0;
+        }
+
+      if (view->using_class_bg && view->class_bg_applied_path
+          && grub_strcmp (path, view->class_bg_applied_path) == 0)
+        {
+          grub_free (path);
+          grub_free (bgs_dir);
+          return 2;
+        }
+
+      grub_video_bitmap_load (&raw, path);
+      grub_errno = GRUB_ERR_NONE;
       if (!raw)
-	continue;
+        {
+          grub_free (path);
+          path = 0;
+          continue;
+        }
+
+      grub_free (view->class_bg_applied_path);
+      view->class_bg_applied_path = path;
+      path = 0;
 
       grub_video_bitmap_destroy (view->raw_desktop_image);
       grub_video_bitmap_destroy (view->scaled_desktop_image);
@@ -241,8 +262,11 @@ maybe_apply_class_background (grub_gfxmenu_view_t view)
       view->scaled_desktop_image = 0;
       view->using_class_bg = 1;
       init_background (view);
+      grub_free (bgs_dir);
       return 1;
     }
+
+  grub_free (bgs_dir);
   return 0;
 }
 
@@ -265,6 +289,7 @@ static void
 sync_class_background_for_current_selection (grub_gfxmenu_view_t view)
 {
   int had_class_bg;
+  int apply_result;
 
   if (!view->class_bg_active || !view->menu)
     return;
@@ -273,7 +298,8 @@ sync_class_background_for_current_selection (grub_gfxmenu_view_t view)
     return;
 
   had_class_bg = view->using_class_bg;
-  if (!maybe_apply_class_background (view) && had_class_bg)
+  apply_result = maybe_apply_class_background (view);
+  if (apply_result == 0 && had_class_bg)
     restore_default_desktop (view);
   view->class_bg_synced_entry = view->selected;
 }
@@ -340,6 +366,7 @@ grub_gfxmenu_view_new (const char *theme_path,
   view->class_bg_active = 0;
   view->default_desktop_raw = 0;
   view->using_class_bg = 0;
+  view->class_bg_applied_path = 0;
 
   /* Set the timeout bar's frame.  */
   view->progress_message_frame.width = view->screen.width * 4 / 5;
@@ -376,6 +403,7 @@ grub_gfxmenu_view_destroy (grub_gfxmenu_view_t view)
   grub_video_bitmap_destroy (view->raw_desktop_image);
   grub_video_bitmap_destroy (view->scaled_desktop_image);
   grub_video_bitmap_destroy (view->default_desktop_raw);
+  grub_free (view->class_bg_applied_path);
   if (view->terminal_box)
     view->terminal_box->destroy (view->terminal_box);
   grub_free (view->terminal_font_name);
@@ -666,7 +694,8 @@ grub_gfxmenu_set_chosen_entry (int entry, void *data)
 {
   grub_gfxmenu_view_t view = data;
   int had_class_bg;
-  int applied;
+  int apply_result;
+  int need_restore_default;
 
   if (!view->class_bg_active)
     {
@@ -675,20 +704,33 @@ grub_gfxmenu_set_chosen_entry (int entry, void *data)
       return;
     }
 
+  if (entry == view->selected)
+    {
+      grub_gfxmenu_redraw_menu (view);
+      return;
+    }
+
   had_class_bg = view->using_class_bg;
   view->selected = entry;
 
-  applied = maybe_apply_class_background (view);
+  apply_result = maybe_apply_class_background (view);
+  view->class_bg_synced_entry = view->selected;
 
-  if (!applied && had_class_bg)
+  if (apply_result == 2)
+    {
+      grub_gfxmenu_redraw_menu (view);
+      return;
+    }
+
+  need_restore_default = (apply_result == 0 && had_class_bg);
+
+  if (need_restore_default)
     restore_default_desktop (view);
 
-  if (applied || had_class_bg)
+  if (apply_result == 1 || need_restore_default)
     gfxmenu_full_redraw_screen (view);
   else
     grub_gfxmenu_redraw_menu (view);
-
-  view->class_bg_synced_entry = view->selected;
 }
 
 void

--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/view.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/view.c
@@ -23,6 +23,8 @@
 #include <grub/mm.h>
 #include <grub/err.h>
 #include <grub/dl.h>
+#include <grub/device.h>
+#include <grub/fs.h>
 #include <grub/normal.h>
 #include <grub/video.h>
 #include <grub/gfxterm.h>
@@ -44,6 +46,217 @@ init_terminal (grub_gfxmenu_view_t view);
 static void
 init_background (grub_gfxmenu_view_t view);
 static grub_gfxmenu_view_t term_view;
+
+static int
+backgrounds_dir_probe_hook (const char *filename __attribute__((unused)),
+			    const struct grub_dirhook_info *info __attribute__((unused)),
+			    void *data __attribute__((unused)))
+{
+  return 0;
+}
+
+static int
+theme_has_backgrounds_dir (const char *theme_path)
+{
+  char *theme_dir = NULL;
+  char *bgs_dir = NULL;
+  char *device_name = NULL;
+  grub_device_t dev = NULL;
+  grub_fs_t fs;
+  const char *path;
+  int ok = 0;
+
+  if (!theme_path)
+    return 0;
+
+  theme_dir = grub_get_dirname (theme_path);
+  if (!theme_dir)
+    return 0;
+
+  bgs_dir = grub_resolve_relative_path (theme_dir, "backgrounds/");
+  grub_free (theme_dir);
+  if (!bgs_dir)
+    return 0;
+
+  device_name = grub_file_get_device_name (bgs_dir);
+  dev = grub_device_open (device_name);
+  if (!dev)
+    goto out;
+
+  fs = grub_fs_probe (dev);
+  path = grub_strchr (bgs_dir, ')');
+  if (path)
+    path++;
+  else
+    path = bgs_dir;
+
+  if (fs && *path)
+    {
+      grub_errno = GRUB_ERR_NONE;
+      (fs->fs_dir) (dev, path, backgrounds_dir_probe_hook, NULL);
+      if (grub_errno == GRUB_ERR_NONE)
+	ok = 1;
+    }
+
+out:
+  grub_errno = GRUB_ERR_NONE;
+  if (dev)
+    grub_device_close (dev);
+  grub_free (device_name);
+  grub_free (bgs_dir);
+  return ok;
+}
+
+static struct grub_video_bitmap *
+clone_video_bitmap (struct grub_video_bitmap *src)
+{
+  struct grub_video_bitmap *dst;
+  void *src_data;
+  void *dst_data;
+  grub_size_t sz;
+
+  if (!src)
+    return 0;
+
+  if (grub_video_bitmap_create (&dst, src->mode_info.width, src->mode_info.height,
+				src->mode_info.blit_format))
+    return 0;
+  src_data = grub_video_bitmap_get_data (src);
+  dst_data = grub_video_bitmap_get_data (dst);
+  sz = (grub_size_t) src->mode_info.width * src->mode_info.height
+       * src->mode_info.bytes_per_pixel;
+  grub_memcpy (dst_data, src_data, sz);
+  return dst;
+}
+
+static void
+setup_class_backgrounds (grub_gfxmenu_view_t view)
+{
+  view->class_bg_active = 0;
+  view->default_desktop_raw = 0;
+  view->using_class_bg = 0;
+
+  if (!view->theme_path || !theme_has_backgrounds_dir (view->theme_path))
+    return;
+
+  if (view->raw_desktop_image)
+    {
+      view->default_desktop_raw = clone_video_bitmap (view->raw_desktop_image);
+      if (!view->default_desktop_raw)
+	return;
+    }
+
+  view->class_bg_active = 1;
+}
+
+static struct grub_video_bitmap *
+try_loading_background_for_class (grub_gfxmenu_view_t view,
+				  const char *class_name)
+{
+  struct grub_video_bitmap *raw = 0;
+  char *theme_dir = 0, *bgs_dir = 0, *path = 0, *p = 0;
+  static const char ext[] = ".png";
+
+  if (!view || !view->theme_path || !class_name)
+    return 0;
+
+  theme_dir = grub_get_dirname (view->theme_path);
+  if (!theme_dir)
+    return 0;
+
+  bgs_dir = grub_resolve_relative_path (theme_dir, "backgrounds/");
+  grub_free (theme_dir);
+  if (!bgs_dir)
+    return 0;
+
+  path = grub_malloc (grub_strlen (bgs_dir) + grub_strlen (class_name)
+		      + grub_strlen (ext) + 3);
+  if (!path)
+    goto out;
+
+  p = grub_stpcpy (path, bgs_dir);
+  if (path == p || p[-1] != '/')
+    *p++ = '/';
+  p = grub_stpcpy (p, class_name);
+  p = grub_stpcpy (p, ext);
+  *p = '\0';
+
+  grub_video_bitmap_load (&raw, path);
+  grub_errno = GRUB_ERR_NONE;
+
+out:
+  grub_free (path);
+  grub_free (bgs_dir);
+  return raw;
+}
+
+static void
+restore_default_desktop (grub_gfxmenu_view_t view)
+{
+  struct grub_video_bitmap *restored;
+
+  grub_video_bitmap_destroy (view->raw_desktop_image);
+  grub_video_bitmap_destroy (view->scaled_desktop_image);
+  view->raw_desktop_image = 0;
+  view->scaled_desktop_image = 0;
+  view->using_class_bg = 0;
+
+  if (!view->default_desktop_raw)
+    return;
+
+  restored = clone_video_bitmap (view->default_desktop_raw);
+  if (!restored)
+    return;
+  view->raw_desktop_image = restored;
+  init_background (view);
+}
+
+/* Returns 1 if a class background was applied.  */
+static int
+maybe_apply_class_background (grub_gfxmenu_view_t view)
+{
+  grub_menu_entry_t entry;
+  struct grub_menu_entry_class *c;
+  struct grub_video_bitmap *raw;
+
+  if (!view || !view->menu)
+    return 0;
+
+  entry = grub_menu_get_entry (view->menu, view->selected);
+  if (!entry)
+    return 0;
+
+  for (c = entry->classes; c; c = c->next)
+    {
+      if (!c->name)
+	continue;
+      raw = try_loading_background_for_class (view, c->name);
+      if (!raw)
+	continue;
+
+      grub_video_bitmap_destroy (view->raw_desktop_image);
+      grub_video_bitmap_destroy (view->scaled_desktop_image);
+      view->raw_desktop_image = raw;
+      view->scaled_desktop_image = 0;
+      view->using_class_bg = 1;
+      init_background (view);
+      return 1;
+    }
+  return 0;
+}
+
+static void
+gfxmenu_full_redraw_screen (grub_gfxmenu_view_t view)
+{
+  grub_video_set_area_status (GRUB_VIDEO_AREA_DISABLED);
+  grub_gfxmenu_view_redraw (view, &view->screen);
+  grub_video_swap_buffers ();
+  if (view->double_repaint)
+    {
+      grub_video_set_area_status (GRUB_VIDEO_AREA_DISABLED);
+      grub_gfxmenu_view_redraw (view, &view->screen);
+    }
+}
 
 /* Create a new view object, loading the theme specified by THEME_PATH and
    associating MODEL with the view.  */
@@ -104,6 +317,9 @@ grub_gfxmenu_view_new (const char *theme_path,
   view->title_text = grub_strdup (_("GRUB Boot Menu"));
   view->progress_message_text = 0;
   view->theme_path = 0;
+  view->class_bg_active = 0;
+  view->default_desktop_raw = 0;
+  view->using_class_bg = 0;
 
   /* Set the timeout bar's frame.  */
   view->progress_message_frame.width = view->screen.width * 4 / 5;
@@ -118,6 +334,8 @@ grub_gfxmenu_view_new (const char *theme_path,
       grub_gfxmenu_view_destroy (view);
       return 0;
     }
+
+  setup_class_backgrounds (view);
 
   return view;
 }
@@ -137,6 +355,7 @@ grub_gfxmenu_view_destroy (grub_gfxmenu_view_t view)
     }
   grub_video_bitmap_destroy (view->raw_desktop_image);
   grub_video_bitmap_destroy (view->scaled_desktop_image);
+  grub_video_bitmap_destroy (view->default_desktop_raw);
   if (view->terminal_box)
     view->terminal_box->destroy (view->terminal_box);
   grub_free (view->terminal_font_name);
@@ -424,11 +643,32 @@ void
 grub_gfxmenu_set_chosen_entry (int entry, void *data)
 {
   grub_gfxmenu_view_t view = data;
+  int prev_using;
 
+  if (!view->class_bg_active)
+    {
+      view->selected = entry;
+      grub_gfxmenu_redraw_menu (view);
+      return;
+    }
+
+  prev_using = view->using_class_bg;
   view->selected = entry;
-  grub_gfxmenu_redraw_menu (view);
 
-  
+  if (maybe_apply_class_background (view))
+    {
+      gfxmenu_full_redraw_screen (view);
+      return;
+    }
+
+  if (prev_using)
+    {
+      restore_default_desktop (view);
+      gfxmenu_full_redraw_screen (view);
+      return;
+    }
+
+  grub_gfxmenu_redraw_menu (view);
 }
 
 void

--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/view.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/view.c
@@ -135,6 +135,7 @@ setup_class_backgrounds (grub_gfxmenu_view_t view)
   view->class_bg_active = 0;
   view->default_desktop_raw = 0;
   view->using_class_bg = 0;
+  view->class_bg_synced_entry = -1;
 
   if (!view->theme_path || !theme_has_backgrounds_dir (view->theme_path))
     return;
@@ -263,17 +264,18 @@ gfxmenu_full_redraw_screen (grub_gfxmenu_view_t view)
 static void
 sync_class_background_for_current_selection (grub_gfxmenu_view_t view)
 {
-  int prev_using;
+  int had_class_bg;
 
   if (!view->class_bg_active || !view->menu)
     return;
 
-  prev_using = view->using_class_bg;
-  if (!maybe_apply_class_background (view))
-    {
-      if (prev_using)
-	restore_default_desktop (view);
-    }
+  if (view->selected == view->class_bg_synced_entry)
+    return;
+
+  had_class_bg = view->using_class_bg;
+  if (!maybe_apply_class_background (view) && had_class_bg)
+    restore_default_desktop (view);
+  view->class_bg_synced_entry = view->selected;
 }
 
 /* Create a new view object, loading the theme specified by THEME_PATH and
@@ -663,7 +665,8 @@ void
 grub_gfxmenu_set_chosen_entry (int entry, void *data)
 {
   grub_gfxmenu_view_t view = data;
-  int prev_using;
+  int had_class_bg;
+  int applied;
 
   if (!view->class_bg_active)
     {
@@ -672,23 +675,20 @@ grub_gfxmenu_set_chosen_entry (int entry, void *data)
       return;
     }
 
-  prev_using = view->using_class_bg;
+  had_class_bg = view->using_class_bg;
   view->selected = entry;
 
-  if (maybe_apply_class_background (view))
-    {
-      gfxmenu_full_redraw_screen (view);
-      return;
-    }
+  applied = maybe_apply_class_background (view);
 
-  if (prev_using)
-    {
-      restore_default_desktop (view);
-      gfxmenu_full_redraw_screen (view);
-      return;
-    }
+  if (!applied && had_class_bg)
+    restore_default_desktop (view);
 
-  grub_gfxmenu_redraw_menu (view);
+  if (applied || had_class_bg)
+    gfxmenu_full_redraw_screen (view);
+  else
+    grub_gfxmenu_redraw_menu (view);
+
+  view->class_bg_synced_entry = view->selected;
 }
 
 void

--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/view.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/gfxmenu/view.c
@@ -258,6 +258,24 @@ gfxmenu_full_redraw_screen (grub_gfxmenu_view_t view)
     }
 }
 
+/* Match desktop to the current selection before first paint (set_chosen_entry
+   is only used when the selection changes).  */
+static void
+sync_class_background_for_current_selection (grub_gfxmenu_view_t view)
+{
+  int prev_using;
+
+  if (!view->class_bg_active || !view->menu)
+    return;
+
+  prev_using = view->using_class_bg;
+  if (!maybe_apply_class_background (view))
+    {
+      if (prev_using)
+	restore_default_desktop (view);
+    }
+}
+
 /* Create a new view object, loading the theme specified by THEME_PATH and
    associating MODEL with the view.  */
 grub_gfxmenu_view_t
@@ -565,6 +583,8 @@ void
 grub_gfxmenu_view_draw (grub_gfxmenu_view_t view)
 {
   init_terminal (view);
+
+  sync_class_background_for_current_selection (view);
 
   init_background (view);
 

--- a/GRUB2/MOD_SRC/grub-2.04/include/grub/gfxmenu_view.h
+++ b/GRUB2/MOD_SRC/grub-2.04/include/grub/gfxmenu_view.h
@@ -123,6 +123,11 @@ struct grub_gfxmenu_view
   int first_timeout;
 
   int *menu_title_offset;
+
+  /* Per-class backgrounds: enabled when theme_dir/backgrounds/ exists.  */
+  int class_bg_active;
+  struct grub_video_bitmap *default_desktop_raw;
+  int using_class_bg;
 };
 
 #endif /* ! GRUB_GFXMENU_VIEW_HEADER */

--- a/GRUB2/MOD_SRC/grub-2.04/include/grub/gfxmenu_view.h
+++ b/GRUB2/MOD_SRC/grub-2.04/include/grub/gfxmenu_view.h
@@ -128,6 +128,7 @@ struct grub_gfxmenu_view
   int class_bg_active;
   struct grub_video_bitmap *default_desktop_raw;
   int using_class_bg;
+  int class_bg_synced_entry;
 };
 
 #endif /* ! GRUB_GFXMENU_VIEW_HEADER */

--- a/GRUB2/MOD_SRC/grub-2.04/include/grub/gfxmenu_view.h
+++ b/GRUB2/MOD_SRC/grub-2.04/include/grub/gfxmenu_view.h
@@ -129,6 +129,7 @@ struct grub_gfxmenu_view
   struct grub_video_bitmap *default_desktop_raw;
   int using_class_bg;
   int class_bg_synced_entry;
+  char *class_bg_applied_path;
 };
 
 #endif /* ! GRUB_GFXMENU_VIEW_HEADER */


### PR DESCRIPTION
Extends the patched gfxmenu so a theme can change backgrounds depending on the _highlighted_ menu entry’s classes, similar to how it's done for `icons/`.

#### How it works:
- If the theme directory contains a `backgrounds/` folder, the feature is enabled
- For the selected entry, GRUB walks **entry->classes** and loads the first match: `backgrounds/<class_name>.png`
- If no matching PNG exists for that entry, the view falls back to the default image (`theme.txt` _desktop-image_).

#### Notes:
- If there is no `backgrounds/` folder, it behaves the same as expected without this feature
- When doing full redraw, you can notice a small delay
- I tried optimizing it without going too far out of scope, but the line count still ended up bigger than I expected

#### How to add to themes

- Simply add a `backgrounds/` directory inside the theme file (same layout idea as `icons/`).
- Create PNGs named after **class** strings (e.g. same classes as in `menu_class` / GRUB `class` on entries).

---
Inspired by https://github.com/elwint/grub-gfxmenu-bg-mod