### PR TITLE
Bump GitHub Actions to fix Node.js 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,26 +12,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Run docker compose up
       run: docker compose up
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: ventoy-windows
         path: INSTALL/ventoy-*windows*
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: ventoy-linux
         path: INSTALL/ventoy-*linux*
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: ventoy-livecd
         path: INSTALL/ventoy-*livecd*
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: SHA256SUM
         path: INSTALL/sha256.txt
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: xxx-build-log
         path: DOC/build.log


### PR DESCRIPTION
Bump actions/checkout from v3 to v6 and actions/upload-artifact from v4 to v7 to resolve the Node.js 20 deprecation warnings.