### PR TITLE
fix: the kcalloc() and kmalloc() calls at cache in cache.c

### DIFF
--- a/SQUASHFS/squashfs-tools-4.4/kernel/kernel-2.6/fs/squashfs/cache.c
+++ b/SQUASHFS/squashfs-tools-4.4/kernel/kernel-2.6/fs/squashfs/cache.c
@@ -241,6 +241,11 @@ struct squashfs_cache *squashfs_cache_init(char *name, int entries,
 		return NULL;
 	}
 
+	if (entries <= 0 || (size_t)entries > SIZE_MAX / sizeof(*(cache->entry))) {
+		ERROR("Invalid entries count for %s cache\n", name);
+		goto cleanup;
+	}
+
 	cache->entry = kcalloc(entries, sizeof(*(cache->entry)), GFP_KERNEL);
 	if (cache->entry == NULL) {
 		ERROR("Failed to allocate %s cache\n", name);
@@ -252,6 +257,10 @@ struct squashfs_cache *squashfs_cache_init(char *name, int entries,
 	cache->entries = entries;
 	cache->block_size = block_size;
 	cache->pages = block_size >> PAGE_CACHE_SHIFT;
+	if (cache->pages <= 0 || (size_t)cache->pages > SIZE_MAX / sizeof(void *)) {
+		ERROR("Invalid pages count for %s cache\n", name);
+		goto cleanup;
+	}
 	cache->name = name;
 	cache->num_waiters = 0;
 	spin_lock_init(&cache->lock);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `SQUASHFS/squashfs-tools-4.4/kernel/kernel-2.6/fs/squashfs/cache.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-004 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-004` |
| **File** | `SQUASHFS/squashfs-tools-4.4/kernel/kernel-2.6/fs/squashfs/cache.c:244` |

**Description**: The kcalloc() and kmalloc() calls at cache.c lines 244, 266, 273, and 402 use `entries` and `pages` values derived directly from the SquashFS image superblock without validating them against architecture-defined maximums. On 32-bit systems, if an attacker crafts an image with an extremely large `entries` value (e.g., 0x40000001 where sizeof(*cache->entry) = 8), the multiplication `entries * sizeof(*(cache->entry))` overflows size_t, resulting in a tiny allocation (e.g., 8 bytes). Subsequent writes to cache->entry[i] for any index i > 0 overflow the undersized buffer, corrupting heap memory.

## Changes
- `SQUASHFS/squashfs-tools-4.4/kernel/kernel-2.6/fs/squashfs/cache.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
