### PR TITLE
Add support for custom persistence config files

### DIFF
--- a/INSTALL/CreatePersistentImg.sh
+++ b/INSTALL/CreatePersistentImg.sh
@@ -12,7 +12,8 @@ print_usage() {
     echo '   -s size in MB, default is 1024'
     echo '   -t filesystem type, default is ext4  ext2/ext3/ext4/xfs are supported now'
     echo '   -l label, default is casper-rw'
-    echo '   -c configfile name inside the persistence file. File content is "/ union"'
+    echo '   -c specify the path to the config file what to be put into the persistence file.'
+    echo '      If not exist, config file name is the path basename and file content is "/ union"'
     echo '   -o outputfile name, default is persistence.dat'
     echo '   -e enable encryption, disabled by default (only few distros support this)'    
     echo ''
@@ -125,7 +126,12 @@ if [ -n "$config" ]; then
     
     mkdir ./persist_tmp_mnt
     if mount $freeloop ./persist_tmp_mnt; then
-        echo '/ union' > ./persist_tmp_mnt/$config
+        config_name="${config##*/}"
+        if [ -f "$config" ]; then
+            cat "$config" > ./persist_tmp_mnt/$config_name
+        else
+            echo '/ union' > ./persist_tmp_mnt/$config_name
+        fi
         sync
         umount ./persist_tmp_mnt
     fi


### PR DESCRIPTION
Added the ability to specify a persistence config file with custom mount points.

## Tests

1. Test `-h` flag
2. Test with `-c` flag with  config file path
3. Test with `-c` flag config file name


### Check `-h` flag

```console
> sudo sh ./CreatePersistentImg.sh -h
Usage:  sudo ./CreatePersistentImg.sh [ -s size ] [ -t fstype ] [ -l LABEL ] [ -c CFG ] [ -e ]
  OPTION: (optional)
   -s size in MB, default is 1024
   -t filesystem type, default is ext4  ext2/ext3/ext4/xfs are supported now
   -l label, default is casper-rw
   -c specify the path to the config file what to be put into the persistence file.
      If not exist, config file name is the path basename and file content is "/ union"
   -o outputfile name, default is persistence.dat
   -e enable encryption, disabled by default (only few distros support this)

```


### Check `-c` flag

Testplan:

1. Enable commands echo with `set -x`
2. Create a persistent with custom `persistence.conf`
3. Mount the persistent as loop
4. Compare source `persistence.conf` and the one from the mounted loop 

Test with `-c filepath`

 ```console
> sudo sh ./CreatePersistentImg.sh -o ../pers.dat -c ../persistence.conf
...
+ [ -n ../persistence.conf ]
+ [ -d ./persist_tmp_mnt ]
+ mkdir ./persist_tmp_mnt
+ mount /dev/loop0 ./persist_tmp_mnt
+ config_name=persistence.conf
+ [ -f ../persistence.conf ]
+ cat ../persistence.conf
+ sync
+ umount ./persist_tmp_mnt
+ rm -rf ./persist_tmp_mnt
+ [ ! -z  ]
+ losetup -d /dev/loop0

> sudo mount -o loop ../pers.dat /tmp/pers/

> diff -s ../persistence.conf /tmp/pers/persistence.conf
Files ../persistence.conf and /tmp/pers/persistence.conf are identical
```

Test with `-c filename`

```console
> sudo sh ./CreatePersistentImg.sh -o ../pers.dat -c persistence.conf
...
+ [ -n persistence.conf ]
+ [ -d ./persist_tmp_mnt ]
+ mkdir ./persist_tmp_mnt
+ mount /dev/loop0 ./persist_tmp_mnt
+ config_name=persistence.conf
+ [ -f persistence.conf ]
+ echo / union
+ sync
+ umount ./persist_tmp_mnt
+ rm -rf ./persist_tmp_mnt
+ [ ! -z  ]
+ losetup -d /dev/loop0

> sudo mount -o loop ../pers.dat /tmp/pers/

> diff -s <(echo '/ union') <(cat /tmp/pers/persistence.conf)
Files /dev/fd/63 and /dev/fd/62 are identical

> cat /tmp/pers/persistence.conf
/ union
``` 
