### PR TITLE
Fix fdisk detection on BusyBox systems

### DIFF
--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -186,7 +186,7 @@ if [ "$MODE" = "install" -a -z "$NONDESTRUCTIVE" ]; then
     else
         if parted -v > /dev/null 2>&1; then
             PARTTOOL='parted'            
-        elif fdisk -v >/dev/null 2>&1; then
+        elif command -v fdisk > /dev/null 2>&1; then
             PARTTOOL='fdisk'            
         else
             vterr "Both parted and fdisk are not found in the system, Ventoy can't create new partitions."


### PR DESCRIPTION
On BusyBox systems, `fdisk -v` exists but returns a non-zero exit code, causing the script in `INSTALL/tool/VentoyWorker.sh` to incorrectly conclude fdisk is not available. This prevents Ventoy from using fdisk as a partition tool on those systems.

Changed the detection from `fdisk -v >/dev/null 2>&1` to `command -v fdisk > /dev/null 2>&1`, which is POSIX-compliant and works reliably regardless of the command's flag behavior.