### PR TITLE
Bugfix Ventoy2Disk.sh: PATH broken when running from outside the script directory

### DIFF
--- a/INSTALL/Ventoy2Disk.sh
+++ b/INSTALL/Ventoy2Disk.sh
@@ -1,12 +1,6 @@
 #!/bin/sh
 
-OLDDIR=$(pwd)
-
-if ! [ -f ./tool/ventoy_lib.sh ]; then
-    if [ -f ${0%Ventoy2Disk.sh}/tool/ventoy_lib.sh ]; then
-        cd ${0%Ventoy2Disk.sh}    
-    fi
-fi
+cd "$(dirname "$0")"
 
 if [ -f ./ventoy/version ]; then
     curver=$(cat ./ventoy/version) 
@@ -21,7 +15,7 @@ elif uname -m | grep -E -q 'mips64'; then
 else
     export TOOLDIR=i386
 fi
-export PATH="$OLDDIR/tool/$TOOLDIR:$PATH"
+export PATH="$(pwd)/tool/$TOOLDIR:$PATH"
 
 
 echo ''
@@ -87,11 +81,4 @@ if [ -f /bin/bash ]; then
     /bin/bash ./tool/VentoyWorker.sh $*
 else
     ash ./tool/VentoyWorker.sh $*
-fi
-
-if [ -n "$OLDDIR" ]; then 
-    CURDIR=$(pwd)
-    if [ "$CURDIR" != "$OLDDIR" ]; then
-        cd "$OLDDIR"
-    fi
 fi


### PR DESCRIPTION
# Motivation

Commit f7e4a7a6 changed `export PATH` from `"./tool/$TOOLDIR:$PATH"` to `"$OLDDIR/tool/$TOOLDIR:$PATH"`, where `OLDDIR=$(pwd)` is captured at the script's very first line.

This broke running `Ventoy2Disk.sh` from any directory other than the script's own directory. The reason is that line 7 conditionally `cd`s into the script's directory when `./tool/ventoy_lib.sh` is not found in the current directory. After that `cd`, `$OLDDIR` still holds the **original** working directory, so the PATH points to the *parent* directory's `tool/` instead of the script's `tool/`, causing `vtoycli` (and other tools) to not be found in `VentoyWorker.sh`.

# Changes

**Proposal 1: Fix PATH resolution (must be evaluated after the `cd` on line 7)**

Replace `$OLDDIR/tool/$TOOLDIR` with `$(pwd)/tool/$TOOLDIR`. After the `cd "$(dirname "$0")"` has run, `pwd` always reflects the script's directory, so the tool path is always correct regardless of where the script is invoked from.

**Proposal 2: Simplify directory detection and remove unnecessary `cd` back**

Replace the complex conditional `cd` logic with a single unconditional `cd "$(dirname "$0")"`. This is simpler, more robust, and works identically in all cases.

The trailing `cd "$OLDDIR"` block was also removed because a shell script's working directory changes do not propagate to the parent process — the `cd` back serves no purpose.