### PR TITLE
Replace mkexfatfs with mkfs.exfat in VentoyWorker.sh

### DIFF
--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -314,16 +314,16 @@ if [ "$MODE" = "install" -a -z "$NONDESTRUCTIVE" ]; then
     wait_and_create_part ${PART1} ${PART2}    
     if [ -b ${PART1} ]; then
         vtinfo "Format partition 1 ${PART1} ..."
-        mkexfatfs -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
+        mkfs.exfat -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
         if [ $? -ne 0 ]; then
-            echo "mkexfatfs failed, now retry..."
-            mkexfatfs -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
+            echo "mkfs.exfat failed, now retry..."
+            mkfs.exfat -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
             if [ $? -ne 0 ]; then
-                echo "######### mkexfatfs failed, exit ########"
+                echo "######### mkfs.exfat failed, exit ########"
                 exit 1
             fi
         else
-            echo "mkexfatfs success"
+            echo "mkfs.exfat success"
         fi        
     else
         vterr "${PART1} NOT exist"


### PR DESCRIPTION
# Motivation

The `mkexfatfs` command was provided by the `fuse-exfat-utils` package (also known as `exfat-utils` on some distributions). This package has been **deprecated since 2021** in favor of `exfatprogs`, which provides native exFAT support via the kernel (since Linux 5.7) without relying on FUSE.

The replacement package `exfatprogs` provides `mkfs.exfat` instead of `mkexfatfs`. Both commands are functionally identical — they create exFAT filesystems with the same options (`-n` for label [^1], `-s` for cluster sectors). The legacy `exfat-utils` package also shipped `mkfs.exfat` as an alias, so this change is backward compatible with older distributions (pre-Ubuntu 22.04, CentOS/RHEL 7/8).

Switching to `mkfs.exfat` ensures Ventoy2Disk works on modern distributions without requiring users to install the deprecated `fuse-exfat-utils` package.

[^1]: https://github.com/exfatprogs/exfatprogs/blob/1fd2d81/mkfs/mkfs.c#L810-L814