### PR TITLE
Bug Fix: missing bounds check in vtoy_json_escape_string

### DIFF
--- a/Plugson/src/Core/ventoy_json.c
+++ b/Plugson/src/Core/ventoy_json.c
@@ -764,40 +764,42 @@ int vtoy_json_destroy(VTOY_JSON *pstJson)
 
 int vtoy_json_escape_string(char *buf, int buflen, const char *str, int newline)
 {
-    char last = 0;
     int count = 0;
 
-    *buf++ = '"';
-    count++;
+    #define PUTC(c) if (count < buflen) buf[count] = (c); count++
 
-    while (*str)
+    PUTC('"');
+    while (str && *str)
     {
-        if (*str == '"' && last != '\\')
+        // safely check
+        if (*str == '"' || *str == '\\' || (unsigned char)*str < 32)
         {
-            *buf = '\\';
-            count++;
-            buf++;
+            PUTC('\\');
+            if (*str == '"') { PUTC('"'); }
+            else if (*str == '\\') { PUTC('\\'); }
+            else if (*str == '\b') { PUTC('b'); }
+            else if (*str == '\f') { PUTC('f'); }
+            else if (*str == '\n') { PUTC('n'); }
+            else if (*str == '\r') { PUTC('r'); }
+            else if (*str == '\t') { PUTC('t'); }
+            else { PUTC('?'); }
         }
-    
-        *buf = *str;
-        count++;
-        buf++;
-
-        last = *str;
+        else
+        {
+            PUTC(*str);
+        }
         str++;
     }
+    PUTC('"');
+    PUTC(',');
+    if (newline) { PUTC('\n'); }
 
-    *buf++ = '"';
-    count++;
-    
-    *buf++ = ',';
-    count++;
-
-    if (newline)
-    {
-        *buf++ = '\n';
-        count++;        
+    // Safe null-termination
+    if (count < buflen) {
+        buf[count] = '\0';
+    } else if (buflen > 0) {
+        buf[buflen - 1] = '\0';
     }
-
+    
     return count;
 }


### PR DESCRIPTION
## Fix buffer overflow in `vtoy_json_escape_string`

This PR fixes the buffer overflow vulnerability in `Plugson/src/Core/ventoy_json.c` inside the `vtoy_json_escape_string` function.

### Issue

The function was writing escaped JSON characters into the destination buffer without validating the `buflen` limit. This could cause out-of-bounds writes when processing long strings or strings requiring escaping. The function also did not guarantee null-termination of the output buffer.

### Fix

* Added bounds checking before every write operation using a safe write helper.
* Ensured the output buffer is always null-terminated when space is available.
* Added safer handling for JSON escaping, including quotes, backslashes, and control characters.
* Prevented writes beyond the provided buffer size.

### Testing

* Verified that normal JSON string escaping still works correctly.
* Tested with long input strings to confirm no out-of-bounds writes occur.
* Verified output remains properly terminated.

Fixes: #3657
